### PR TITLE
WIP Rails in production on ecs

### DIFF
--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -43,8 +43,6 @@ services:
       SOLR_URL: http://localhost:8983/solr/blacklight-core
       POSTGRES_HOST: localhost
       IIIF_MANIFESTS_BASE_URL: /manifests/
-      RAILS_ENV: production
-      RACK_ENV: production
       PASSENGER_APP_ENV: production
 
   management:
@@ -57,8 +55,6 @@ services:
     environment:
       SOLR_BASE_URL: http://localhost:8983/solr
       POSTGRES_HOST: localhost
-      RAILS_ENV: production
-      RACK_ENV: production
       PASSENGER_APP_ENV: production
 
 

--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -43,6 +43,9 @@ services:
       SOLR_URL: http://localhost:8983/solr/blacklight-core
       POSTGRES_HOST: localhost
       IIIF_MANIFESTS_BASE_URL: /manifests/
+      RAILS_ENV: production
+      RACK_ENV: production
+      PASSENGER_APP_ENV: production
 
   management:
     logging:
@@ -54,3 +57,8 @@ services:
     environment:
       SOLR_BASE_URL: http://localhost:8983/solr
       POSTGRES_HOST: localhost
+      RAILS_ENV: production
+      RACK_ENV: production
+      PASSENGER_APP_ENV: production
+
+


### PR DESCRIPTION
Sets the passenger environment to `production` for the blacklight and management apps. This is WIP because it depends on the blacklight and management app having secret_key_base set up.