### PR TITLE
Add Yul-base Dockerfile to coordinate a base across projects

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,38 @@
+FROM phusion/passenger-ruby26:1.0.10
+
+RUN echo 'Downloading Packages' && \
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update -qq && \
+  apt-get install -y --no-install-recommends \
+    build-essential \
+    libsasl2-dev \
+    nodejs \
+    rsync \
+    tzdata \
+    yarn \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  echo 'Packages Downloaded'
+
+# Install Chrome so we can run system specs for Blacklight
+RUN apt-get update && apt-get install -y wget && \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' && \
+  apt-get update && \
+  apt-get install -y google-chrome-stable && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  echo 'Chrome installed'
+
+RUN yarn && \
+  yarn config set no-progress && \
+  yarn config set silent
+
+RUN rm /etc/nginx/sites-enabled/default
+
+ENV APP_HOME /home/app/webapp
+RUN mkdir $APP_HOME && chown -R app $APP_HOME
+WORKDIR $APP_HOME

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,7 @@
+# Yul-DC Base
+
+This Dockerfile represents a common base for all Rails based apps in our stack to work from.  This will allow for 
+simpler updates and more controlled changes to dependencies and for faster deployment and dev pulls for all.
+
+It builds on the Phusion Passenger based Dockerfiles found here https://github.com/phusion/passenger-docker and 
+adds some commond OS level dependencies that we need for our projects such as Node and Yarn.

--- a/base/README.md
+++ b/base/README.md
@@ -4,4 +4,4 @@ This Dockerfile represents a common base for all Rails based apps in our stack t
 simpler updates and more controlled changes to dependencies and for faster deployment and dev pulls for all.
 
 It builds on the Phusion Passenger based Dockerfiles found here https://github.com/phusion/passenger-docker and 
-adds some commond OS level dependencies that we need for our projects such as Node and Yarn.
+adds some common OS level dependencies that we need for our projects such as Node and Yarn.

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  base:
+    build: .
+    image: yalelibraryit/dc-base:v0.0.1
+


### PR DESCRIPTION
This will allow us to use a single more uniform base across projects
and rely on Dockers caching and layer system to speed up and solidy
our build and deployment processes.