### PR TITLE
Test local or deployed blacklight

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+inherit_gem:
+  bixby: bixby_default.yml
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/deploy_spec.rb
+
+RSpec/DescribeClass:
+  Exclude:
+    - spec/deploy_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,10 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'github_changelog_generator'
+gem 'http'
+gem 'rspec'
+
+group :development, :test do
+  gem 'bixby'
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,10 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    byebug (11.1.3)
     concurrent-ruby (1.1.6)
+    diff-lcs (1.3)
+    dotenv (2.7.5)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.2.0)
@@ -34,6 +37,19 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     retriable (3.1.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -46,7 +62,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
+  dotenv
   github_changelog_generator
+  rspec
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ bin/add-alb.sh gobstopper
 bin/deploy-full.sh gobstopper
 ```
 
+## Running the deployment test against a deployed cluster
+
+1. `bundle install`
+2. Set YUL_DC_SERVER to the domain name for your deployed cluster `export YUL_DC_SERVER=collections-test.curationexperts.com`
+3. `rspec spec/deploy_spec.rb`
+
 ## Releasing a new version
 
 1. Decide on a new version number. We use [semantic versioning](https://github.com/yalelibrary/yul-dc-camerata/wiki/Semantic-Versioning).

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'byebug'
+require 'json'
+require 'http'
+
+username = ENV['HTTP_USERNAME']
+password = ENV['HTTP_PASSWORD']
+server = ENV['YUL_DC_SERVER']
+server ||= 'localhost'
+local_server_names = ['127.0.0.1', 'localhost']
+if local_server_names.include? server
+  blacklight_port = ':3000'
+  manifest_port = ''
+  prefix = 'http://'
+  iiif_port = ':8182'
+else
+  blacklight_port = ''
+  manifest_port = ''
+  prefix = 'https://'
+  iiif_port = ''
+end
+RSpec.describe "The cluster at #{server}" do
+  describe "The blacklight site at #{server}" do
+    let(:uri) { "#{prefix}#{server}#{blacklight_port}/" }
+    it 'accepts the provided HTTP_PASSWORD and HTTP_USERNAME' do
+      response = HTTP.basic_auth(user: username, pass: password).get(uri)
+      expect(response.code).to eq(200)
+    end
+    it 'loads home page with a language facet present' do
+      response = HTTP.basic_auth(user: username, pass: password).get(uri)
+      expect(response.code).to eq(200)
+      expect(response.body).to match(/blacklight-language_ssim/)
+    end
+    describe 'has search results' do
+      let(:uri) { "#{prefix}#{server}#{blacklight_port}/?search_field=all_fields&q=" }
+      it 'with at least 5 pages' do
+        response = HTTP.basic_auth(user: username, pass: password).get(uri)
+        expect(response.code).to eq(200)
+        expect(response.body).to match(/aria-label="Go to page 5"/)
+      end
+    end
+    describe 'has a public item' do
+      let(:uri) { "#{prefix}#{server}#{blacklight_port}/catalog/16189097" }
+      it 'that shows Universal Viewer' do
+        response = HTTP.basic_auth(user: username, pass: password).get(uri)
+        expect(response.code).to eq(200)
+        expect(response.body).to match(/universal-viewer-iframe/)
+      end
+    end
+    describe 'has a yale-only item' do
+      let(:uri) { URI("#{prefix}#{server}#{blacklight_port}/catalog/16189097-yale") }
+      it 'that does not show Universal Viewer' do
+        response = HTTP.basic_auth(user: username, pass: password).get(uri)
+        expect(response.code).to eq(200)
+        expect(response.body).not_to match(/universal-viewer-iframe/)
+      end
+    end
+  end
+
+  describe "The manifest service at #{server}" do
+    let(:uri) { "#{prefix}#{server}#{manifest_port}/manifests/#{oid}\.json" }
+    describe 'provides a manifest for item 16686591' do
+      let(:oid) { '16685691' }
+      it 'serves a manifest for item 16685691 with a sequence containing one canvas' do
+        response = HTTP.get(uri)
+        expect(response.code).to eq(200)
+        expect(JSON.parse(response.body)['sequences'][0]['canvases'].length).to eq(1)
+      end
+    end
+    describe 'provides a manifest for item 16856582' do
+      let(:oid) { '16854582' }
+      it 'has a sequence with nine canvases' do
+        response = HTTP.get(uri)
+        expect(response.code).to eq(200)
+        expect(JSON.parse(response.body)['sequences'][0]['canvases'].length).to eq(9)
+      end
+    end
+  end
+
+  describe "The iiif service at #{server}" do
+    let(:uri) { "#{prefix}#{server}#{iiif_port}/iiif/2/#{oid}/info.json" }
+    let(:oid) { '16854589' }
+    it 'serves an info.json for image 16854589 that has a width/height ratio between 0.75 and 0.8' do
+      response = HTTP.get(uri)
+      expect(response.code).to eq(200)
+      parsed = JSON.parse(response.body)
+      expect(parsed['width'].to_f / parsed['height'].to_f).to be_between(0.75, 0.8).inclusive
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end


### PR DESCRIPTION
Rspec suite tests that a local or deployed YUL-DC cluster 
* has a blacklight app with a language facet, at least 40 search results, and Universal Viewer for a public object but not a yale-only object
* has a manifest service that delivers some parseable manifests
* has a iiif image service that delivers a parseable info.json  (https://github.com/yalelibrary/YUL-DC/issues/230)