### PR TITLE
Prepare for manifest service v.2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,25 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
+    bixby (3.0.0)
+      rubocop (= 0.85.1)
+      rubocop-performance
+      rubocop-rails
+      rubocop-rspec
     byebug (11.1.3)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
-    dotenv (2.7.5)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
+    ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     github_changelog_generator (1.15.2)
       activesupport
       faraday-http-cache
@@ -25,6 +36,16 @@ GEM
       rainbow (>= 2.2.1)
       rake (>= 10.0)
       retriable (~> 3.0)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     minitest (5.14.1)
@@ -33,10 +54,16 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.19.1)
+    parser (2.7.1.3)
+      ast (~> 2.4.0)
     public_suffix (4.0.5)
+    rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)
+    regexp_parser (1.7.1)
     retriable (3.1.2)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -50,21 +77,46 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.85.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.0.3)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
+    rubocop-performance (1.6.1)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.6.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.82.0)
+    rubocop-rspec (1.40.0)
+      rubocop (>= 0.68.1)
+    ruby-progressbar (1.10.1)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+    unicode-display_width (1.7.0)
     zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bixby
   byebug
-  dotenv
   github_changelog_generator
+  http
   rspec
 
 BUNDLED WITH

--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -7,6 +7,9 @@ services:
         awslogs-group: ${CLUSTER_NAME}
         awslogs-region: ${AWS_DEFAULT_REGION}
         awslogs-stream-prefix: iiif_manifest
+    environment:
+      IIIF_MANIFESTS_BASE_URL: 'https://$$host/manifests/'
+      IIIF_IMAGE_BASE_URL: 'https://$$host/iiif'
 
   solr:
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: yalelibraryit/dc-iiif-manifest:${IIIF_MANIFEST_VERSION}
     ports:
       - '80:80'
-        environment:
-    IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
-    IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
+    environment:
+      IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
+      IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
 
   solr:
     image: yalelibraryit/dc-solr:${SOLR_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     image: yalelibraryit/dc-iiif-manifest:${IIIF_MANIFEST_VERSION}
     ports:
       - '80:80'
+        environment:
+    IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
+    IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
 
   solr:
     image: yalelibraryit/dc-solr:${SOLR_VERSION}


### PR DESCRIPTION
v2.0.0 of the manifest service https://github.com/yalelibrary/yul-dc-iiif-manifest will require the IIIF_IMAGE_BASE_URL and IIIF_MANIFESTS_BASE_URL to be set for the discovery app to display images in both production and development environments.
Preliminary work connected to https://github.com/yalelibrary/YUL-DC/issues/237