### PR TITLE
Configure camerata to run containers in Rails production mode on ECS

### DIFF
--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -33,7 +33,7 @@ services:
       options:
         awslogs-group: ${CLUSTER_NAME}
         awslogs-region: ${AWS_DEFAULT_REGION}
-        awslogs-stream-prefix: db_blacklight
+        awslogs-stream-prefix: db
 
   blacklight:
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   db:
     image: yalelibraryit/dc-postgres:${POSTGRES_VERSION}
     environment:
-      POSTGRES_MULTIPLE_DATABASES: blacklight_yul_development,yul_dc_management_development
+      POSTGRES_MULTIPLE_DATABASES: blacklight_yul_production,yul_dc_management_production
       POSTGRES_HOST: db
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -47,14 +47,13 @@ services:
     image: yalelibraryit/dc-blacklight:${BLACKLIGHT_VERSION}
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && /sbin/my_init"
     environment:
-      POSTGRES_DB: blacklight_yul_production
       POSTGRES_HOST: db
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       SOLR_URL: http://solr:8983/solr/blacklight-core
       IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
-      # PASSENGER_APP_ENV: development
       PASSENGER_APP_ENV: production
+      RAILS_ENV: production
       HTTP_PASSWORD_PROTECT: 'true'
       BLACKLIGHT_VERSION:
       RAILS_MASTER_KEY:
@@ -62,8 +61,8 @@ services:
       - .secrets
     ports:
       - "3000:3000"
-    # volumes:
-      # - blacklight:/home/app/webapp
+    volumes:
+      - blacklight:/home/app/webapp
     depends_on:
       - db
       - solr
@@ -82,6 +81,7 @@ services:
       SOLR_BASE_URL: http://solr:8983/solr
       SOLR_CORE: blacklight-core
       PASSENGER_APP_ENV: production
+      RAILS_ENV: production
       MANAGEMENT_VERSION:
       RAILS_MASTER_KEY:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
       - .secrets
     ports:
       - "3000:3000"
-    volumes:
-      - blacklight:/home/app/webapp
+    # volumes:
+      # - blacklight:/home/app/webapp
     depends_on:
       - db
       - solr
@@ -81,7 +81,7 @@ services:
       POSTGRES_PASSWORD: password
       SOLR_BASE_URL: http://solr:8983/solr
       SOLR_CORE: blacklight-core
-      PASSENGER_APP_ENV: development
+      PASSENGER_APP_ENV: production
       MANAGEMENT_VERSION:
       RAILS_MASTER_KEY:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     image: yalelibraryit/dc-blacklight:${BLACKLIGHT_VERSION}
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && /sbin/my_init"
     environment:
-      POSTGRES_DB: blacklight_yul_development
+      POSTGRES_DB: blacklight_yul_production
       POSTGRES_HOST: db
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,11 @@ services:
       POSTGRES_PASSWORD: password
       SOLR_URL: http://solr:8983/solr/blacklight-core
       IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
-      PASSENGER_APP_ENV: development
+      # PASSENGER_APP_ENV: development
+      PASSENGER_APP_ENV: production
       HTTP_PASSWORD_PROTECT: 'true'
       BLACKLIGHT_VERSION:
+      RAILS_MASTER_KEY:
     env_file:
       - .secrets
     ports:
@@ -80,6 +82,8 @@ services:
       SOLR_BASE_URL: http://solr:8983/solr
       SOLR_CORE: blacklight-core
       PASSENGER_APP_ENV: development
+      MANAGEMENT_VERSION:
+      RAILS_MASTER_KEY:
     ports:
       - "3001:3001"
     depends_on:


### PR DESCRIPTION
* Allow deployment scripts to pass `RAILS_MASTER_KEY` set in the local environment
* Set `PASSENGER_APP_ENV` & `RAILS_ENV` to production in running containers
* Change database configurations to reference production