### PR TITLE
Pass Honeybadger API Keys to ECS clusters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       RAILS_ENV: production
       HTTP_PASSWORD_PROTECT: 'true'
       BLACKLIGHT_VERSION:
+      HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY_BLACKLIGHT}
+      # Set the master key in your local environment to pass through to ECS
       RAILS_MASTER_KEY:
     env_file:
       - .secrets
@@ -81,6 +83,8 @@ services:
       SOLR_CORE: blacklight-core
       PASSENGER_APP_ENV: production
       RAILS_ENV: production
+      HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY_MANAGEMENT}
+      # Set the master key in your local environment to pass through to ECS
       RAILS_MASTER_KEY:
       # The management app needs the versions for all the applications for the dashboard
       IIIF_MANIFEST_VERSION:

--- a/secrets-template
+++ b/secrets-template
@@ -1,4 +1,8 @@
 AWS_ACCESS_KEY_ID=your_aws_access_key_id_here
 AWS_SECRET_KEY=your_aws_secret_key_here
+
 HTTP_USERNAME=blacklight_basic_auth_username
 HTTP_PASSWORD=blacklight_basic_auth_password
+
+HONEYBADGER_API_KEY_BLACKLIGHT=see settings for https://app.honeybadger.io/projects/72587
+HONEYBADGER_API_KEY_MANAGEMENT=see settings for https://app.honeybadger.io/projects/72674


### PR DESCRIPTION
Use either `.secrets` or locally set environment variables to
pass Honeybadger API keys for exception reporting.

HONEYBADGER_API_KEY_BLACKLIGHT
HONEYBADGER_API_KEY_MANAGEMENT