### PR TITLE
Add a deployment check for the RAILS_MASTER_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Valid combinations of memory and cpu documented here: <https://docs.aws.amazon.c
 bin/deploy-full.sh $CLUSTER_NAME
 ```
 
-This command deploys the full Yale stack to the named cluster. You must have a valid params file obtained by running `bin/get-params` against your cluster first. You must also create a `.secrets` file with valid S3 credentials and basic auth credentials; see `secrets-template` for the correct format.
+This command deploys the full Yale stack to the named cluster. You must have a valid params file obtained by running `bin/get-params` against your cluster first. You must also create a `.secrets` file with valid S3 credentials and basic auth credentials; see `secrets-template` for the correct format.  For deployments to complete succesfully you also need to set a 16-byte (32 character) RAILS_MASTER_KEY provided by your team lead.
 
 ### Configure a load balancer
 

--- a/bin/deploy-full.sh
+++ b/bin/deploy-full.sh
@@ -3,7 +3,7 @@ set -e
 
 . $(dirname "$0")/shared-checks.sh
 
-if check_profile && check_region && check_cluster $1 && check_params $1 && check_secrets && all_pass
+if check_profile && check_region && check_cluster $1 && check_params $1 && check_secrets && check_master_key && all_pass
 then
   echo "Target cluster: ${1}"
   export CLUSTER_NAME=${1}

--- a/bin/shared-checks.sh
+++ b/bin/shared-checks.sh
@@ -43,6 +43,15 @@ check_secrets() {
   fi
 }
 
+check_master_key() {
+  if [[ ${#RAILS_MASTER_KEY} != 32 ]]
+  then
+    echo "ERROR: Please ensure you have a valid 16-byte (32 hex characters) RAILS_MASTER_KEY set."
+    errors="true"
+  fi
+}
+
+
 all_pass() {
   if [[ -z "$errors" ]]
   then


### PR DESCRIPTION
The RAILS_MASTER_KEY is used to decrypt encoded credentials checked into
the yul-dc-blacklight and yul-dc-management repos.  We have agreed to use
the same credentials for both repos and to share the encryption key out-of-band
with team members.

The key must be a 32-character hex string representing a 16-byte encoding key.
The key must be set in the shell environment of the machine running the `deploy-full.sh`
script.

For more details see https://edgeguides.rubyonrails.org/security.html#environmental-security