### PR TITLE
Move CircleCI to be DockerCompose Based To Mimic Local Smoke Test Runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,67 +15,44 @@ commands:
           docker tag <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
 jobs:
   run-tests:
-    docker:
-      - image: circleci/ruby:2.6.6-node-browsers
-        environment:
-          BLACKLIGHT_URL: http://blacklight.library.yale.edu:3000
-          BUNDLER_VERSION: 2.1.4
-          IIIF_IMAGE_URL: http://cantaloup:8182
-          IIIF_MANIFEST_URL: http://iiif-manifest
-      - name: blacklight.library.yale.edu
-        image: yalelibraryit/dc-blacklight:v1.3.1
-        environment:
-          HTTP_PASSWORD: test
-          HTTP_PASSWORD_PROTECT: 'true'
-          HTTP_USERNAME: test
-          IIIF_MANIFESTS_BASE_URL: http://iiif-manifest/manifests/
-          PASSENGER_APP_ENV: development
-          POSTGRES_DB: blacklight_yul_development
-          POSTGRES_HOST: db
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: postgres
-          SOLR_URL: http://solr:8983/solr/blacklight-test
-      - name: iiif-manifest
-        image: yalelibraryit/dc-iiif-manifest:v1.1.2
-      - name: solr
-        image: yalelibraryit/dc-solr:v1.0.0
-        command: bash -c 'precreate-core blacklight-test /opt/config; exec solr -f'
-      - name: cantaloup
-        image: yalelibraryit/dc-iiif-cantaloupe:v1.0.0
-        environment:
-          S3CACHE_BUCKET_NAME: yale-image-samples/cantaloupe/cache #NO TRAILING SLASH!
-          S3_SOURCE_BUCKET_NAME: yale-image-samples
-      - name: db
-        image: yalelibraryit/dc-postgres:v1.0.0
-        environment:
-          POSTGRES_MULTIPLE_DATABASES: blacklight_yul_development,yul_dc_management_development
-          POSTGRES_HOST: db
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-      - name: management
-        image: yalelibraryit/dc-management:v1.4.1
-        environment:
-          PASSENGER_APP_ENV: development
-          POSTGRES_DB: yul_dc_management_development
-          POSTGRES_HOST: db
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: postgres
-          SOLR_BASE_URL: http://solr:8983/solr
-          SOLR_CORE: blacklight-test
-    executor: docker/docker
+    machine:
+      image: ubuntu-1604:202004-01
     steps:
-      - setup_remote_docker
       - checkout
       - run:
           name: Bundler
-          command: gem install bundler -v 2.1.4 && bundle
+          command: |
+            gem install bundler -v 2.1.4 && bundle
       - run:
           name: Rubocop
-          command: bundle exec rubocop --parallel
+          command: |
+            bundle exec rubocop --parallel
+      - run:
+          name: Setup Secrets
+          command: |
+            echo HTTP_USERNAME=test >> .secrets
+            echo HTTP_PASSWORD=test >> .secrets
+            echo AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} >> .secrets
+            echo AWS_SECRET_KEY=${AWS_SECRET_KEY} >> .secrets
+      - run:
+          name: Docker Compose Up
+          command: |
+            set -x
+            docker-compose up -d
+      - run:
+          name: Wait for services to be fully up
+          command: |
+            wget --tries 10 --retry-connrefused http://localhost:8983/solr/
+            wget --tries 10 --retry-connrefused http://test:test@localhost:3001
+            wget --tries 10 --retry-connrefused http://test:test@localhost:3000
+      - run:
+          name: populate management index
+          command: |
+            docker-compose exec management bundle exec rake yale:index_fixture_data METADATA_SOURCE=ladybird
       - run:
           name: rspec
           command:  |
-            HTTP_USERNAME=test HTTP_PASSWORD=test bundle exec rspec --tag "~ci_pending"
+            bundle exec rspec
 orbs:
   docker: circleci/docker@1.0.1
 version: 2.1

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -25,7 +25,7 @@ puts "Current Blacklight basic auth settings: " \
 # Checks for cluster urls in ENV
 # Sets to local development defaults if none are found
 blacklight_url = ENV['BLACKLIGHT_URL'] || 'http://localhost:3000'
-iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'http://localhost:8080'
+iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'http://localhost:80'
 iiif_image_url = ENV['IIIF_IMAGE_URL'] || 'http://localhost:8182'
 
 RSpec.describe "The cluster at #{blacklight_url}" do


### PR DESCRIPTION
Moves to a machine based approach on Circle. This is slightly slower, but in the Camerata case, not significantly so (it costs about 30s on average in my testing). The advantages are a few fold:

- No duplication between docker-compose.yml and .circleci/config
- Read from the same place for getting current versions of the upstream images as running locally does. This means no more syncing vars to CircleCI's project repo. Even though that command line tool made it easy, it was a manual step and going to get forgotten.
- ENV vars (both locally and via context/project) can be properly sent in to all the containers, not just the primary one. Even if we got around `RAILS_MASTER_KEY`, the **AWS** keys were a show stopper for all our other approaches on this.
- SSH debugging is much easier in CI, as you can stop and start the services with full docker-compose

Small cleanup notes:

- Once this is merged, all the version vars in the circleci project should be removed
- The AWS keys in the CircleCI Camerta project are currently mine. These should be replaced by a more locked down set for CI. I'm pretty sure its just bucket read they need, once I confirm that, I'll write up a ticket for it.
- Because we forwent so much other work that happened on the several branches around this code (including the CI variable tool and other items) I pulled this final form in to its own branch. We can clean up the other branches if we agree this is the way forward, but I didn't want to squash other work until we decided that.