### PR TITLE
Provide version numbers to containers through gem

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -27,12 +27,14 @@ if ENV['YUL_DC_SERVER']
   blacklight_url = "https://#{username}:#{password}@#{ENV['YUL_DC_SERVER']}"
   iiif_manifest_url = "https://#{ENV['YUL_DC_SERVER']}"
   iiif_image_url = "https://#{ENV['YUL_DC_SERVER']}"
+  management_url = "https://#{ENV['YUL_DC_SERVER']}/management"
 else
   # Checks for cluster urls in ENV
   # Sets to local development defaults if none are found
   blacklight_url = ENV['BLACKLIGHT_URL'] || "http://#{username}:#{password}@localhost:3000"
   iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'http://localhost:80'
   iiif_image_url = ENV['IIIF_IMAGE_URL'] || 'http://localhost:8182'
+  management_url = ENV['MANAGEMENT_URL'] || 'http://localhost:3001/management'
 end
 
 # use this SSLContext to use https URLs without verifying certificates
@@ -48,6 +50,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       visit uri
       expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
+      expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/), "with a version number"
       click_on 'search'
       expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
     end
@@ -119,4 +122,37 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       expect(parsed['width'].to_f / parsed['height'].to_f).to be_between(0.75, 0.8).inclusive
     end
   end
+  describe "The management index page at #{management_url}" do
+    it "has at least six version numbers in the table" do
+      # skipping looking for the first row of the version number table for the
+      # moment -- will add CSS to make this easier in the management app
+      # in a later PR.
+      visit management_url
+      find("tr:nth-child(2)")
+      within("tr:nth-child(2)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+      find("tr:nth-child(3)")
+      within("tr:nth-child(3)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+      find("tr:nth-child(4)")
+      within("tr:nth-child(4)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+      find("tr:nth-child(5)")
+      within("tr:nth-child(5)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+      find("tr:nth-child(6)")
+      within("tr:nth-child(6)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+      find("tr:nth-child(7)")
+      within("tr:nth-child(7)") do
+        expect(page).to have_content(/v\d+\.\d+\.\d+/)
+      end
+    end
+  end
+
 end

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -154,5 +154,4 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       end
     end
   end
-
 end

--- a/templates/blacklight-compose.yml
+++ b/templates/blacklight-compose.yml
@@ -7,5 +7,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
       SOLR_URL: http://solr:8983/solr/blacklight-core
+      BLACKLIGHT_VERSION:
     ports:
       - '3000:3000'

--- a/templates/db-compose.yml
+++ b/templates/db-compose.yml
@@ -7,5 +7,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_MULTIPLE_DATABASES: blacklight_yul_development,management_yul_development
+      POSTGRES_VERSION:
     ports:
       - "5432:5432"

--- a/templates/iiif-images-compose.ecs.yml
+++ b/templates/iiif-images-compose.ecs.yml
@@ -7,4 +7,5 @@ services:
         awslogs-group: ${CLUSTER_NAME}
         awslogs-region: ${AWS_DEFAULT_REGION}
         awslogs-stream-prefix: iiif_image
-
+    environment:
+      HONEYBADGER_API_KEY_IMAGESERVER:

--- a/templates/iiif-images-compose.yml
+++ b/templates/iiif-images-compose.yml
@@ -7,5 +7,6 @@ services:
       AWS_SECRET_KEY: ${AWS_SECRET_ACCESS_KEY}
       S3CACHE_BUCKET_NAME: yale-image-samples/cantaloupe/cache #NO TRAILING SLASH!
       S3_SOURCE_BUCKET_NAME: yale-image-samples
+      IIIF_IMAGE_VERSION:  
     ports:
       - '8182:8182'

--- a/templates/iiif-manifest-compose.yml
+++ b/templates/iiif-manifest-compose.yml
@@ -7,3 +7,4 @@ services:
     environment:
       IIIF_MANIFESTS_BASE_URL: http://localhost/manifests/
       IIIF_IMAGE_BASE_URL: http://localhost:8182/iiif
+      IIIF_MANIFEST_VERSION:

--- a/templates/management-compose.yml
+++ b/templates/management-compose.yml
@@ -17,5 +17,13 @@ services:
       SOLR_BASE_URL: http://solr:8983/solr
       SOLR_CORE: blacklight-core
       VPN:
+      # The management app needs the versions for all the applications for the dashboard
+      IIIF_MANIFEST_VERSION:
+      SOLR_VERSION:
+      IIIF_IMAGE_VERSION:
+      POSTGRES_VERSION:
+      BLACKLIGHT_VERSION:
+      MANAGEMENT_VERSION:
+      CAMERATA_VERSION:
     ports:
       - "3001:3001"

--- a/templates/solr-compose.yml
+++ b/templates/solr-compose.yml
@@ -5,4 +5,5 @@ services:
     ports:
       - '8983:8983'
     command: bash -c 'precreate-core blacklight-core /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
-
+    environment:
+      SOLR_VERSION:


### PR DESCRIPTION
Also added check to the deploy tests that the blacklight and management front pages are displaying version numbers.