### PR TITLE
Updates to merge Yale & DCE deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docker-compose-merged.yml
 
 # rspec failure tracking
 .rspec_status
+vendor

--- a/README.md
+++ b/README.md
@@ -206,8 +206,13 @@ Second and third parameters, if present, set the memory and cpu
 size for the task (defaults to 8GB and 2048) -- decreased memory
 example
 
+## Note: In the DCE environment, you should set PUBLIC_IP=ENABLED
+## when fetching parameters (including when running other deploy scripts
+## when you have no parameters present), or you will have a bad
+## time.
+
 ```
-cam get-params $CLUSTER_NAME 4GB 2048
+PUBLIC_IP=ENABLED cam get-params $CLUSTER_NAME 4GB 2048
 ```
 
 Valid combinations of memory and cpu documented here:
@@ -266,7 +271,7 @@ resource allocation.
 1. `cam build-cluster $CLUSTER_NAME` to build the cluster
 1. (optional) `cam get-params $CLUSTER_NAME` to read the
 configuration data for your new cluster
-1. `cam add-alb $CLUSTER_NAME` add a
+1. `DOMAIN_NAME='*.your-domain-name' cam add-alb $CLUSTER_NAME` add a
 load balancer for your new cluster (NOTE: This has to happen _before_
 you will be able to deploy)
 1. `cam deploy-solr $CLUSTER_NAME --enable-service-discovery`

--- a/bin/add-alb.sh
+++ b/bin/add-alb.sh
@@ -35,12 +35,16 @@ then
       --stack-name amazon-ecs-cli-setup-${1} \
           --query "(StackResourceSummaries[?LogicalResourceId=='Vpc'].PhysicalResourceId)[0]" \
           | sed -e 's/^"//' -e 's/"$//' `
+    DEFAULT_VPC_SG=`aws ec2 describe-security-groups \
+      --filters Name=vpc-id,Values=$VPC_ID \
+        --query "(SecurityGroups[?GroupName=='default'])[0].GroupId" \
+          | grep -Eo -m 1 'sg-\w+'`
+    else
+      DEFAULT_VPC_SG=`aws ec2 describe-security-groups \
+        --filters Name=vpc-id,Values=$VPC_ID \
+          --query "(SecurityGroups[?GroupName=='$CLUSTER_NAME-sg'])[0].GroupId" \
+            | grep -Eo -m 1 'sg-\w+'`
   fi
-
-  DEFAULT_VPC_SG=`aws ec2 describe-security-groups \
-    --filters Name=vpc-id,Values=$VPC_ID \
-      --query "(SecurityGroups[?GroupName=='$CLUSTER_NAME-sg'])[0].GroupId" \
-        | grep -Eo -m 1 'sg-\w+'`
 
   echo "Extracting existing configuration"
   echo "  $VPC_ID"

--- a/bin/deploy-main.sh
+++ b/bin/deploy-main.sh
@@ -11,6 +11,7 @@ then
 
   if [[ ! -f ${1}-ecs-params.yml ]]
   then
+    export PUBLIC_IP
     $(dirname "$0")/get-params.sh ${1}
   fi
 

--- a/bin/deploy-psql.sh
+++ b/bin/deploy-psql.sh
@@ -12,6 +12,7 @@ then
 
   if [[ ! -f ${1}-psql-params.yml ]]
   then
+    export PUBLIC_IP
     $(dirname "$0")/get-params.sh ${1}
   fi
 

--- a/bin/deploy-solr.sh
+++ b/bin/deploy-solr.sh
@@ -12,6 +12,7 @@ then
 
   if [[ ! -f ${1}-solr-params.yml ]]
   then
+    export PUBLIC_IP
     $(dirname "$0")/get-params.sh ${1}
   fi
   if [[ $(aws ecs describe-services --cluster $1 --services $1-solr) = *MISSING* ]]

--- a/bin/get-params.sh
+++ b/bin/get-params.sh
@@ -15,7 +15,7 @@ then
 else
   cpu=$3
 fi
-
+PUBLIC_IP=${PUBLIC_IP:-DISABLED}
 
 if check_profile && check_region && check_cluster $1 && all_pass
 then
@@ -71,11 +71,11 @@ run_params:
         - $SUBNET1
       security_groups:
         - $SG_ID
-      assign_public_ip: ENABLED
+      assign_public_ip: $PUBLIC_IP
   service_discovery:
     container_name: solr
     private_dns_namespace:
-      name: local
+      name: $CLUSTER_NAME
       vpc: $VPC_ID
 
 ECS_PARAMS
@@ -102,11 +102,11 @@ run_params:
         - $SUBNET1
       security_groups:
         - $SG_ID
-      assign_public_ip: ENABLED
+      assign_public_ip: $PUBLIC_IP
   service_discovery:
     container_name: db
     private_dns_namespace:
-      name: local
+      name: $CLUSTER_NAME
       vpc: $VPC_ID
 
 ECS_PARAMS
@@ -127,10 +127,10 @@ run_params:
         - $SUBNET1
       security_groups:
         - $SG_ID
-      assign_public_ip: ENABLED
+      assign_public_ip: $PUBLIC_IP
   service_discovery:
     private_dns_namespace:
-      name: local
+      name: $CLUSTER_NAME
       vpc: $VPC_ID
 ECS_PARAMS
 else

--- a/docker-compose.ecs.yml
+++ b/docker-compose.ecs.yml
@@ -29,8 +29,8 @@ services:
         awslogs-region: ${AWS_DEFAULT_REGION}
         awslogs-stream-prefix: blacklight
     environment:
-      SOLR_URL: http://${CLUSTER_NAME}-solr.local:8983/solr/blacklight-core
-      POSTGRES_HOST: ${CLUSTER_NAME}-psql.local
+      SOLR_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr/blacklight-core
+      POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
       IIIF_MANIFESTS_BASE_URL: /manifests/
       HONEYBADGER_API_KEY: 1979eb78
       HONEYBADGER_API_KEY_BLACKLIGHT: 1979eb78
@@ -43,7 +43,7 @@ services:
         awslogs-region: ${AWS_DEFAULT_REGION}
         awslogs-stream-prefix: management
     environment:
-      SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.local:8983/solr
-      POSTGRES_HOST: ${CLUSTER_NAME}-psql.local
+      SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr
+      POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
       HONEYBADGER_API_KEY: 057e1879
       HONEYBADGER_API_KEY_MANAGEMENT: 057e1879

--- a/templates/blacklight-compose.ecs.yml
+++ b/templates/blacklight-compose.ecs.yml
@@ -8,10 +8,10 @@ services:
       HTTP_USERNAME: ${HTTP_USERNAME}
       IIIF_MANIFESTS_BASE_URL: /manifests/
       PASSENGER_APP_ENV: ${RAILS_ENV:-production}
-      POSTGRES_HOST: ${CLUSTER_NAME}-psql.local
+      POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
       RAILS_ENV: ${RAILS_ENV:-production}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
-      SOLR_URL: http://${CLUSTER_NAME}-solr.local:8983/solr/blacklight-core
+      SOLR_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr/blacklight-core
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && /sbin/my_init" # server
     logging:
       driver: awslogs

--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -9,8 +9,8 @@ services:
       POSTGRES_DB: management_yul_production
       PASSENGER_APP_ENV: ${RAILS_ENV:-production}
       RAILS_ENV: ${RAILS_ENV:-production}
-      SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.local:8983/solr
-      POSTGRES_HOST: ${CLUSTER_NAME}-psql.local
+      SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr
+      POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
     logging:
       driver: awslogs
       options:


### PR DESCRIPTION
* use cluster-specific private domains, resolves "too many overlapping
zones" problem
* set assign_public_ip function based on whether in Yale, or DCE env
* ignore vendored gems in .gitignore
* uses default security group in the DCE cases
* export PUBLIC_IP to get-params when called from other scripts