### PR TITLE
Make smoke tests pass on the small seed dataset

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -54,9 +54,8 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
       expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/), "with a version number"
       click_on 'search'
-      if deployed
-        expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
-      end
+      expect(page).to have_selector(".document-position-6"), "an open search has at least six items"
+      expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages" if deployed
     end
     it 'is local or has a valid SSL certificate' do
       # this method is using the HTTP gem instead of capybara because
@@ -74,7 +73,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       end
     end
     describe 'has a yale-only item' do
-      let(:uri) { "#{blacklight_url}/catalog/16189097-yale" }
+      let(:uri) { "#{blacklight_url}/catalog/2000002107188" }
       it 'that does not show Universal Viewer' do
         visit uri
         expect(page).not_to have_selector(".universal-viewer-iframe")

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -24,6 +24,7 @@ puts "Current Blacklight basic auth settings: " \
 
 # Checked for a deployed cluster host in the environment
 if ENV['YUL_DC_SERVER']
+  deployed = true
   blacklight_url = "https://#{username}:#{password}@#{ENV['YUL_DC_SERVER']}"
   iiif_manifest_url = "https://#{ENV['YUL_DC_SERVER']}"
   iiif_image_url = "https://#{ENV['YUL_DC_SERVER']}"
@@ -35,6 +36,7 @@ else
   iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'http://localhost:80'
   iiif_image_url = ENV['IIIF_IMAGE_URL'] || 'http://localhost:8182'
   management_url = ENV['MANAGEMENT_URL'] || 'http://localhost:3001/management'
+  deployed = false
 end
 
 # use this SSLContext to use https URLs without verifying certificates
@@ -52,7 +54,9 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
       expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/), "with a version number"
       click_on 'search'
-      expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
+      if deployed
+        expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
+      end
     end
     it 'is local or has a valid SSL certificate' do
       # this method is using the HTTP gem instead of capybara because


### PR DESCRIPTION
Related to https://github.com/yalelibrary/yul-dc-management/pull/220 and https://github.com/yalelibrary/YUL-DC/issues/460

This doesn't resolve the concern mentioned in https://github.com/yalelibrary/yul-dc-camerata/pull/127 of the yale-only test object being unavailable in environments with Yale VPN access, but I think that'll be ok until tomorrow.