### PR TITLE
Fix secrets copy from default ns

### DIFF
--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -141,11 +141,6 @@ module Camerata
     end
     map rc: :console
 
-    def create_param_name(target_ns, source_ns, name)
-      param_base = source_ns.strip.empty? ? name : name.split("#{source_ns}_")[1]
-      "#{target_ns}_#{param_base}"
-    end
-
     desc "env_copy TARGET_NS SOURCE_NS", "copy params from env to another"
     def env_copy(target_ns, source_ns = "")
       app_versions = Camerata::AppVersions.get_all source_ns
@@ -155,10 +150,10 @@ module Camerata
            "\n SECRETS: #{secrets}"
 
       # Refactor to .each on an argument (app_versions, secrets, eventually cluster params)
-      copy_param_set(app_versions, target_ns, source_ns)
+      Camerata::Parameters.copy_param_set(app_versions, target_ns, source_ns)
       secrets.each do |name, version|
         # Skip set when looking at AWS Credentials
-        Camerata::Parameters.set(create_param_name(target_ns, source_ns, name), version, true) unless name == "AWS_ACCESS_KEY_ID" || name == "AWS_SECRET_ACCESS_KEY"
+        Camerata::Parameters.set(Camerata::Parameters.create_param_name(target_ns, source_ns, name), version, true) unless name == "AWS_ACCESS_KEY_ID" || name == "AWS_SECRET_ACCESS_KEY"
       end
     end
 
@@ -278,12 +273,6 @@ module Camerata
         db_only_compose
       when 'deploy-solr'
         solr_only_compose
-      end
-    end
-
-    def copy_param_set(group, source_ns, target_ns)
-      group.each do |name, version|
-        Camerata::Parameters.set(create_param_name(target_ns, source_ns, name), version)
       end
     end
 

--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -143,20 +143,30 @@ module Camerata
 
     desc "env_copy TARGET_NS SOURCE_NS", "copy params from env to another"
     def env_copy(target_ns, source_ns = "")
+      # Collect all app_versions and secrets
       app_versions = Camerata::AppVersions.get_all source_ns
       secrets = Camerata::Secrets.get_all source_ns
+
+      # Output the collected list of app versions and secrets
+      # Without source_ns APP VERSIONS: { "BLACKLIGHT_VERSION"=>"v1.15.1", "CAMERATA_VERSION"=>"v2.4.0" ...}
+      # With source_ns set to "YUL_DEPLOY" APP VERSIONS: { "YUL_DEPLOY_BLACKLIGHT_VERSION"=>"v1.15.1", "YUL_DEPLOY_CAMERATA_VERSION"=>"v2.4.0" ...}
       puts "\n Copying following parameters from source to #{target_ns} namespace: " \
            "\n APP VERSIONS: #{app_versions}" \
            "\n SECRETS: #{secrets}"
 
-      # Refactor to .each on an argument (app_versions, secrets, eventually cluster params)
+      # Using the list from app_versions, create new params with the target_ns prefixed to param name
+      # copy_param_set should be using create_param_name method to create the new namespaced param name
       Camerata::Parameters.copy_param_set(app_versions, target_ns, source_ns)
+
+      # Using the list from secrets, create new params with the target_ns prefixed to param name
+      # Also uses create_param_name to create the new namespaced param name
       secrets.each do |name, version|
         # Skip set when looking at AWS Credentials
         Camerata::Parameters.set(Camerata::Parameters.create_param_name(target_ns, source_ns, name), version, true) unless name == "AWS_ACCESS_KEY_ID" || name == "AWS_SECRET_ACCESS_KEY"
       end
     end
 
+    # what does env_copy do
     desc "env_get KEY", "get value of a parameter"
     def env_get(key)
       result = Camerata::Parameters.get(key)

--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -149,12 +149,13 @@ module Camerata
            "\n APP VERSIONS: #{app_versions}" \
            "\n SECRETS: #{secrets}"
 
-      app_versions.each do |app, version|
-        param_base = app.split("#{source_ns}_")[1]
-        Camerata::Parameters.set("#{target_ns}_#{param_base}", version)
-      end
+      # Refactor to .each on an argument (app_versions, secrets, eventually cluster params)
+      copy_param_set(app_versions)
       secrets.each do |app, version|
-        param_base = app == "AWS_ACCESS_KEY_ID" || app == "AWS_SECRET_ACCESS_KEY" ? app : app.split("#{source_ns}_")[1]
+        # Don't set AWS credentials
+        # TODO: Skip set when looking at AWS Credentials
+        # param_base = app == "AWS_ACCESS_KEY_ID" || app == "AWS_SECRET_ACCESS_KEY" ? app : app.split("#{source_ns}_")[1]
+        param_base = source_ns.strip.empty? ? app : app.split("#{source_ns}_")[1]
         Camerata::Parameters.set("#{target_ns}_#{param_base}", version, true)
       end
     end
@@ -275,6 +276,13 @@ module Camerata
         db_only_compose
       when 'deploy-solr'
         solr_only_compose
+      end
+    end
+
+    def copy_param_set(group)
+      group.each do |app, version|
+        param_base = source_ns.strip.empty? ? app : app.split("#{source_ns}_")[1]
+        Camerata::Parameters.set("#{target_ns}_#{param_base}", version)
       end
     end
 

--- a/lib/camerata/parameters.rb
+++ b/lib/camerata/parameters.rb
@@ -6,6 +6,7 @@ module Camerata
       raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
       key = "\"#{key}\"" unless key.match?('"')
       result = call_aws_ssm(key)
+      # byebug
       JSON.parse(result) if result && !result.empty?
     end
 
@@ -43,8 +44,12 @@ module Camerata
       puts "Setting #{key} param value to #{value}. Secret: #{secret}"
       raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
       type = secret ? 'SecureString' : 'String'
-      result = `aws ssm put-parameter --name "#{key}" --type #{type} --value "#{value}" --overwrite`
+      result = put_parameter(key, value, secret)
       JSON.parse(result) if result && !result.empty?
+    end
+
+    def self.put_parameter(key, value, secret = false)
+      `aws ssm put-parameter --name "#{key}" --type #{type} --value "#{value}" --overwrite`
     end
 
     def self.load_env

--- a/lib/camerata/parameters.rb
+++ b/lib/camerata/parameters.rb
@@ -13,6 +13,17 @@ module Camerata
       `aws ssm get-parameters --names #{key} --with-decryption`
     end
 
+    def self.copy_param_set(group, source_ns, target_ns)
+      group.each do |name, version|
+        Camerata::Parameters.set(create_param_name(target_ns, source_ns, name), version)
+      end
+    end
+
+    def self.create_param_name(target_ns, source_ns, name)
+      param_base = source_ns.strip.empty? ? name : name.split("#{source_ns}_")[1]
+      "#{target_ns}_#{param_base}"
+    end
+
     # rubocop:disable Naming/AccessorMethodName
     def self.get_hash(key)
       json = get(key)

--- a/lib/camerata/parameters.rb
+++ b/lib/camerata/parameters.rb
@@ -13,14 +13,18 @@ module Camerata
       `aws ssm get-parameters --names #{key} --with-decryption`
     end
 
-    def self.copy_param_set(group, source_ns, target_ns)
+    def self.copy_param_set(group, target_ns, source_ns)
       group.each do |name, version|
-        Camerata::Parameters.set(create_param_name(target_ns, source_ns, name), version)
+        set(create_param_name(target_ns, source_ns, name), version)
       end
     end
 
     def self.create_param_name(target_ns, source_ns, name)
+      # Gets param name base by removing any ns prefixes from param name
+      # param_base of "YUL_TEST_BLACKLIGHT_VERSION" --> "BLACKLIGHT_VERSION"
+      # param_base defaults to name if source_ns is empty
       param_base = source_ns.strip.empty? ? name : name.split("#{source_ns}_")[1]
+      # Returns the new param name with target_ns prefixed to base
       "#{target_ns}_#{param_base}"
     end
 

--- a/lib/camerata/parameters.rb
+++ b/lib/camerata/parameters.rb
@@ -6,12 +6,11 @@ module Camerata
       raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
       key = "\"#{key}\"" unless key.match?('"')
       result = call_aws_ssm(key)
-      # byebug
       JSON.parse(result) if result && !result.empty?
     end
 
     def self.call_aws_ssm(key)
-      `aws ssm get-parameters --names #{key}`
+      `aws ssm get-parameters --names #{key} --with-decryption`
     end
 
     # rubocop:disable Naming/AccessorMethodName
@@ -43,12 +42,12 @@ module Camerata
     def self.set(key, value, secret = false)
       puts "Setting #{key} param value to #{value}. Secret: #{secret}"
       raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
-      type = secret ? 'SecureString' : 'String'
       result = put_parameter(key, value, secret)
       JSON.parse(result) if result && !result.empty?
     end
 
     def self.put_parameter(key, value, secret = false)
+      type = secret ? 'SecureString' : 'String'
       `aws ssm put-parameter --name "#{key}" --type #{type} --value "#{value}" --overwrite`
     end
 

--- a/lib/camerata/secrets.rb
+++ b/lib/camerata/secrets.rb
@@ -12,17 +12,6 @@ module Camerata
       ]
     end
 
-    # def self.get(key)
-    #   raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
-    #   key = "\"#{key}\"" unless key.match?('"')
-    #   result = call_aws_ssm(key)
-    #   JSON.parse(result) if result && !result.empty?
-    # end
-
-    # def self.call_aws_ssm(key)
-    #   `aws ssm get-parameters --names #{key} --with-decryption`
-    # end
-
     # rubocop:disable Naming/AccessorMethodName
     def self.get_all(namespace = "")
       hash = super

--- a/lib/camerata/secrets.rb
+++ b/lib/camerata/secrets.rb
@@ -15,8 +15,12 @@ module Camerata
     def self.get(key)
       raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
       key = "\"#{key}\"" unless key.match?('"')
-      result = `aws ssm get-parameters --names #{key} --with-decryption`
+      result = call_aws_ssm(key)
       JSON.parse(result) if result && !result.empty?
+    end
+
+    def self.call_aws_ssm(key)
+      `aws ssm get-parameters --names #{key} --with-decryption`
     end
 
     # rubocop:disable Naming/AccessorMethodName

--- a/lib/camerata/secrets.rb
+++ b/lib/camerata/secrets.rb
@@ -12,16 +12,16 @@ module Camerata
       ]
     end
 
-    def self.get(key)
-      raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
-      key = "\"#{key}\"" unless key.match?('"')
-      result = call_aws_ssm(key)
-      JSON.parse(result) if result && !result.empty?
-    end
+    # def self.get(key)
+    #   raise 'please set your AWS_PROFILE and AWS_DEFAULT_REGION' unless ENV['AWS_DEFAULT_REGION'] && ENV['AWS_PROFILE']
+    #   key = "\"#{key}\"" unless key.match?('"')
+    #   result = call_aws_ssm(key)
+    #   JSON.parse(result) if result && !result.empty?
+    # end
 
-    def self.call_aws_ssm(key)
-      `aws ssm get-parameters --names #{key} --with-decryption`
-    end
+    # def self.call_aws_ssm(key)
+    #   `aws ssm get-parameters --names #{key} --with-decryption`
+    # end
 
     # rubocop:disable Naming/AccessorMethodName
     def self.get_all(namespace = "")

--- a/spec/camerata_cli_spec.rb
+++ b/spec/camerata_cli_spec.rb
@@ -62,34 +62,4 @@ RSpec.describe Camerata::CLI do
     it 'should have all the parts needed for the application specified'
     it 'should default to blacklight (aka the whole stack)'
   end
-
-  context 'env_get' do
-    ENV['AWS_PROFILE'] = nil # make sure we can't actually hit aws
-    let(:output) { capture(:stdout) { cli.env_get "TEST_PARAM" } }
-    it 'gets the value of a param from the param store' do
-      expect(output).to match("TEST_VAL")
-    end
-  end
-
-  context 'env_set' do
-    ENV['AWS_PROFILE'] = nil # make sure we can't actually hit aws
-    let(:output) { capture(:stdout) { cli.env_set("TEST_PARAM", "TEST_VALUE", true) } }
-    it 'sets a param in the param store' do
-      expect(output).to match("")
-    end
-  end
-
-  context 'env_copy' do
-    ENV['AWS_PROFILE'] = nil # make sure we can't actually hit aws
-
-    let(:output) { capture(:stdout) { cli.env_copy "TEST_TARGET_NS" } }
-
-    it 'requires a target "namespace"' do
-      expect { capture(:stdout) { cli.env_copy } }.to raise_error(ArgumentError)
-    end
-
-    it 'copies a set of params over to a new set of namespaced params' do
-      expect(output).to match('Copying following parameters from source to TEST_TARGET_NS namespace:')
-    end
-  end
 end

--- a/spec/camerata_env_spec.rb
+++ b/spec/camerata_env_spec.rb
@@ -1,18 +1,15 @@
+# frozen_string_literal: true
 RSpec.describe Camerata::CLI do
   subject(:cli) { described_class.new }
   before do
-    # parameters = class_double('Camerata::Parameters').as_stubbed_const(transfer_nested_constants: true)
-    allow(Camerata::Parameters).to receive(:put_parameter).and_return("somestring")
-    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{}")
-    
-    # secrets = class_double('Camerata::Secrets').as_stubbed_const(transfer_nested_constants: true)
-    allow(Camerata::Secrets).to receive(:call_aws_ssm).and_return('{ "Parameters" => [{ "Name" => "TEST_PARAM", "Type" => "String", "Value" => "TEST_VAL" }] }')
+    allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:229792048549:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
   end
 
-  around(:each) do |example|
+  around do |example|
     aws_profile = ENV['AWS_PROFILE']
     aws_default_region = ENV['AWS_DEFAULT_REGION']
     ENV['AWS_PROFILE'] = 'a-user'
@@ -25,7 +22,7 @@ RSpec.describe Camerata::CLI do
   context 'env_get' do
     let(:output) { capture(:stdout) { cli.env_get "TEST_PARAM" } }
     it 'gets the value of a param from the param store' do
-      expect(output).to match("TEST_VAL")
+      expect(output).to match("v1.15.1")
     end
   end
 

--- a/spec/camerata_env_spec.rb
+++ b/spec/camerata_env_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Camerata::CLI do
   subject(:cli) { described_class.new }
   before do
     allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
-    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:some-identifying-number:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\",\n}]}")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")

--- a/spec/camerata_env_spec.rb
+++ b/spec/camerata_env_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Camerata::CLI do
   subject(:cli) { described_class.new }
   before do
     allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
-    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\",\n}]}")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\"\n}]}")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")

--- a/spec/camerata_env_spec.rb
+++ b/spec/camerata_env_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Camerata::CLI do
   subject(:cli) { described_class.new }
   before do
     allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
-    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:229792048549:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:some-identifying-number:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")

--- a/spec/camerata_env_spec.rb
+++ b/spec/camerata_env_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Camerata::CLI do
+  subject(:cli) { described_class.new }
+  before do
+    # parameters = class_double('Camerata::Parameters').as_stubbed_const(transfer_nested_constants: true)
+    allow(Camerata::Parameters).to receive(:put_parameter).and_return("somestring")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{}")
+    
+    # secrets = class_double('Camerata::Secrets').as_stubbed_const(transfer_nested_constants: true)
+    allow(Camerata::Secrets).to receive(:call_aws_ssm).and_return('{ "Parameters" => [{ "Name" => "TEST_PARAM", "Type" => "String", "Value" => "TEST_VAL" }] }')
+    allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
+    allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
+    allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
+  end
+
+  around(:each) do |example|
+    aws_profile = ENV['AWS_PROFILE']
+    aws_default_region = ENV['AWS_DEFAULT_REGION']
+    ENV['AWS_PROFILE'] = 'a-user'
+    ENV['AWS_DEFAULT_REGION'] = 'somestring'
+    example.run
+    ENV['AWS_PROFILE'] = aws_profile
+    ENV['AWS_DEFAULT_REGION'] = aws_default_region
+  end
+
+  context 'env_get' do
+    let(:output) { capture(:stdout) { cli.env_get "TEST_PARAM" } }
+    it 'gets the value of a param from the param store' do
+      expect(output).to match("TEST_VAL")
+    end
+  end
+
+  context 'env_set' do
+    let(:output) { capture(:stdout) { cli.env_set("TEST_PARAM", "TEST_VALUE", true) } }
+    it 'sets a param in the param store' do
+      expect(output).to match("")
+    end
+  end
+
+  context 'env_copy' do
+    let(:output) { capture(:stdout) { cli.env_copy "TEST_TARGET_NS" } }
+
+    it 'requires a target "namespace"' do
+      expect { capture(:stdout) { cli.env_copy } }.to raise_error(ArgumentError)
+    end
+
+    it 'copies a set of params over to a new set of namespaced params' do
+      expect(output).to match('Copying following parameters from source to TEST_TARGET_NS namespace:')
+    end
+  end
+end

--- a/spec/camerata_parameters_spec.rb
+++ b/spec/camerata_parameters_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 RSpec.describe Camerata::Parameters do
   before do
-    allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
-    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:some-identifying-number:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
+    allow(described_class).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
+    allow(described_class).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\",\n}]}")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
@@ -41,11 +41,11 @@ RSpec.describe Camerata::Parameters do
 
   context "create_param_name" do
     it "creates a new ssm param name" do
-      expect(Camerata::Parameters.create_param_name("TARGET_NS", "SOURCE_NS", "SOURCE_NS_PARAM")).to match("TARGET_NS_PARAM")
+      expect(described_class.create_param_name("TARGET_NS", "SOURCE_NS", "SOURCE_NS_PARAM")).to match("TARGET_NS_PARAM")
     end
 
     it "creates appropriate ssm param name when source ns not provided" do
-      expect(Camerata::Parameters.create_param_name("TARGET_NS", "", "PARAM")).to match("TARGET_NS_PARAM")
+      expect(described_class.create_param_name("TARGET_NS", "", "PARAM")).to match("TARGET_NS_PARAM")
     end
   end
 end

--- a/spec/camerata_parameters_spec.rb
+++ b/spec/camerata_parameters_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Camerata::Parameters do
   before do
     allow(described_class).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
-    allow(described_class).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\",\n}]}")
+    allow(described_class).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Value\": \"v1.15.1\"\n}]}")
     allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")

--- a/spec/camerata_parameters_spec.rb
+++ b/spec/camerata_parameters_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe Camerata::Parameters do
   before do
+    allow(Camerata::Parameters).to receive(:put_parameter).and_return("{\n    \"Version\": 1,\n    \"Tier\": \"Standard\"\n}\n")
+    allow(Camerata::Parameters).to receive(:call_aws_ssm).and_return("{\n    \"Parameters\": [\n        {\n            \"Name\": \"BLACKLIGHT_VERSION\",\n            \"Type\": \"String\",\n            \"Value\": \"v1.15.1\",\n            \"Version\": 24,\n            \"LastModifiedDate\": \"2020-09-02T11:09:53.862000-07:00\",\n            \"ARN\": \"arn:aws:ssm:us-east-1:some-identifying-number:parameter/BLACKLIGHT_VERSION\",\n            \"DataType\": \"text\"\n        }\n    ],\n    \"InvalidParameters\": []\n}\n")
+    allow(Camerata::Secrets).to receive(:aws_secret_access_key).and_return("a-secret-key")
+    allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
+    allow(Camerata::Secrets).to receive(:aws_access_key_id).and_return("an-access-key-id")
     # Stubbing call to aws cli so this can be a unit test
     allow(described_class).to receive(:call_aws_ssm).and_return(File.open(File.join("spec", "fixtures", 'camerata_version.json')).read)
     # stubbing the parameters method which is ordinarily provided by a subclass
@@ -26,11 +31,21 @@ RSpec.describe Camerata::Parameters do
     ENV['AWS_DEFAULT_REGION'] = region
   end
 
-  it "gets a CAMERATA_VERSION" do
-    expect(described_class.get("ANYTHING")["Parameters"].first["Name"]).to eq "CAMERATA_VERSION"
-  end
+  # it "gets a CAMERATA_VERSION" do
+  #   expect(described_class.get("ANYTHING")["Parameters"].first["Name"]).to eq "CAMERATA_VERSION"
+  # end
 
-  it "turns ssm params into hash" do
-    expect(described_class.get_hash("ANYTHING")["CAMERATA_VERSION"]).to eq "v2.4.0"
+  # it "turns ssm params into hash" do
+  #   expect(described_class.get_hash("ANYTHING")["CAMERATA_VERSION"]).to eq "v2.4.0"
+  # end
+
+  context "create_param_name" do
+    it "creates a new ssm param name" do
+      expect(Camerata::Parameters.create_param_name("TARGET_NS", "SOURCE_NS", "SOURCE_NS_PARAM")).to match("TARGET_NS_PARAM")
+    end
+
+    it "creates appropriate ssm param name when source ns not provided" do
+      expect(Camerata::Parameters.create_param_name("TARGET_NS", "", "PARAM")).to match("TARGET_NS_PARAM")
+    end
   end
 end


### PR DESCRIPTION
Refactors the env_copy method and specs:
- Establishes a subroutine for creating param names
- Establishes a subroutine for copying string parameters