### PR TITLE
Separate the gem tests from the local-development integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ jobs:
           command:  |
             bundle exec rspec smoke_spec
   run-tests:
-    machine:
-      image: ubuntu-1604:202004-01
+    docker:
+      - image: circleci/ruby:2.6-stretch-node-browsers-legacy
     steps:
       - checkout
       - run:
@@ -60,40 +60,26 @@ jobs:
           command: |
             gem install bundler -v 2.1.4 && bundle
       - run:
-          name: Rubocop
+          name: aws-cli
           command: |
-            bundle exec rubocop --parallel
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install
+            sudo curl -Lo /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest
+            sudo chmod +x /usr/local/bin/ecs-cli
       - run:
-          name: Setup Secrets
+          name: Set up aws
           command: |
-            echo HTTP_USERNAME=test >> .secrets
-            echo HTTP_PASSWORD=test >> .secrets
             echo AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} >> .secrets
             echo AWS_SECRET_KEY=${AWS_SECRET_KEY} >> .secrets
             mkdir -p ~/.aws
             echo ${AWS_PROFILE_VALUE} | base64 -d > ~/.aws/credentials
       - run:
-          name: Docker Compose Up
-          environment:
-            RAILS_ENV: development
+          name: Rubocop
           command: |
-            set -x
-            ls -l
-            bundle exec ./exe/camerata up -d
+            bundle exec rubocop --parallel
       - run:
           name: rspec
           command:  |
             bundle exec rspec
-      - run:
-          name: Wait for services to be fully up
-          command: |
-            wget --tries 10 --retry-connrefused http://localhost:8983/solr/
-            wget --tries 10 --retry-connrefused http://test:test@localhost:3001
-            wget --tries 10 --retry-connrefused http://test:test@localhost:3000
-      - run:
-          name: smoke specs
-          command:  |
-            bundle exec rspec smoke_spec
   deploy-smoke:
     docker:
       - image: circleci/ruby:2.6-stretch-node-browsers-legacy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,42 @@ commands:
       - run: >
           docker tag <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
 jobs:
+  local-smoke:
+    machine:
+      image: ubuntu-1604:202004-01
+    steps:
+      - checkout
+      - run:
+          name: Bundler
+          command: |
+            gem install bundler -v 2.1.4 && bundle
+      - run:
+          name: Setup Secrets
+          command: |
+            echo HTTP_USERNAME=test >> .secrets
+            echo HTTP_PASSWORD=test >> .secrets
+            echo AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} >> .secrets
+            echo AWS_SECRET_KEY=${AWS_SECRET_KEY} >> .secrets
+            mkdir -p ~/.aws
+            echo ${AWS_PROFILE_VALUE} | base64 -d > ~/.aws/credentials
+      - run:
+          name: Docker Compose Up
+          environment:
+            RAILS_ENV: development
+          command: |
+            set -x
+            ls -l
+            bundle exec ./exe/camerata up -d
+      - run:
+          name: Wait for services to be fully up
+          command: |
+            wget --tries 10 --retry-connrefused http://localhost:8983/solr/
+            wget --tries 20 --retry-connrefused http://test:test@localhost:3001
+            wget --tries 20 --retry-connrefused http://test:test@localhost:3000
+      - run:
+          name: smoke specs
+          command:  |
+            bundle exec rspec smoke_spec
   run-tests:
     machine:
       image: ubuntu-1604:202004-01
@@ -104,9 +140,9 @@ workflows:
             branches:
               only:
                 - master
-                - deploy-from-circle
+                - smoke-scheduled-only
     jobs:
       - deploy-smoke:
           context: yul-dc
-      - run-tests:
+      - local-smoke:
           context: yul-dc


### PR DESCRIPTION
* Run the local-development smoke tests in the scheduled workflow only
* Increase the startup delay the local-development smoke tests tolerate
* Run the specs and style checks for the gem code in the commit workflow only