### PR TITLE
Match local-mode smoke test to seeds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camerata (3.0.0)
+    camerata (3.0.1)
       activesupport (~> 6.0.0)
       capybara (~> 3.33.0)
       http (~> 4.4.1)

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -24,7 +24,6 @@ puts "Current Blacklight basic auth settings: " \
 
 # Checked for a deployed cluster host in the environment
 if ENV['YUL_DC_SERVER']
-  deployed = true
   blacklight_url = "https://#{username}:#{password}@#{ENV['YUL_DC_SERVER']}"
   iiif_manifest_url = "https://#{ENV['YUL_DC_SERVER']}"
   iiif_image_url = "https://#{ENV['YUL_DC_SERVER']}"
@@ -36,7 +35,6 @@ else
   iiif_manifest_url = ENV['IIIF_MANIFEST_URL'] || 'http://localhost:80'
   iiif_image_url = ENV['IIIF_IMAGE_URL'] || 'http://localhost:8182'
   management_url = ENV['MANAGEMENT_URL'] || 'http://localhost:3001/management'
-  deployed = false
 end
 
 # use this SSLContext to use https URLs without verifying certificates
@@ -52,10 +50,12 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       visit uri
       expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
-      expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/), "with a version number"
+      expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/)
       click_on 'search'
-      expect(page).to have_selector(".document-position-6"), "an open search has at least six items"
-      expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages" if deployed
+      expect(page).to have_selector(".document-position-4"), "an open search has at least 5 items"
+      if ENV['YUL_DC_SERVER']
+        expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
+      end
     end
     it 'is local or has a valid SSL certificate' do
       # this method is using the HTTP gem instead of capybara because

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -53,9 +53,11 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/)
       click_on 'search'
       expect(page).to have_selector(".document-position-4"), "an open search has at least 5 items"
-      if ENV['YUL_DC_SERVER']
-        expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
-      end
+    end
+    it 'has multiple pages of results in deployed environments', deployed: true do
+      visit uri
+      click_on 'search'
+      expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
     end
     it 'is local or has a valid SSL certificate' do
       # this method is using the HTTP gem instead of capybara because

--- a/smoke_spec/spec_helper.rb
+++ b/smoke_spec/spec_helper.rb
@@ -18,4 +18,5 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
   config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_excluding deployed: true unless ENV['YUL_DC_SERVER']
 end


### PR DESCRIPTION
Check for at least five pages of search results in deployed 
environments.  Remove unused "deployed" variable.