### PR TITLE
Using environment vars for metadata cloud host

### DIFF
--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -8,6 +8,7 @@ services:
       IIIF_MANIFESTS_BASE_URL: 'https://collections-test.library.yale.edu/manifests'
       MC_USER: ${MC_USER}
       MC_PW: ${MC_PW}
+      METADATA_CLOUD_HOST:
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       HONEYBADGER_API_KEY_MANAGEMENT: ${HONEYBADGER_API_KEY_MANAGEMENT}
       POSTGRES_DB: management_yul_production
@@ -31,6 +32,7 @@ services:
       IIIF_MANIFESTS_BASE_URL: 'https://collections-test.library.yale.edu/manifests'
       MC_USER: ${MC_USER}
       MC_PW: ${MC_PW}
+      METADATA_CLOUD_HOST: 
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       HONEYBADGER_API_KEY_MANAGEMENT: ${HONEYBADGER_API_KEY_MANAGEMENT}
       POSTGRES_DB: management_yul_production

--- a/templates/management-compose.yml
+++ b/templates/management-compose.yml
@@ -11,6 +11,7 @@ services:
       IIIF_MANIFESTS_BASE_URL: ${IIIF_MANIFESTS_BASE_URL:-http://localhost/manifests/}
       MC_USER:
       MC_PW:
+      METADATA_CLOUD_HOST:
       PASSENGER_APP_ENV: development # development
       POSTGRES_DB: management_yul_development
       POSTGRES_HOST: db
@@ -47,6 +48,7 @@ services:
       IIIF_MANIFESTS_BASE_URL: ${IIIF_MANIFESTS_BASE_URL:-http://localhost/manifests/}
       MC_USER:
       MC_PW:
+      METADATA_CLOUD_HOST:
       PASSENGER_APP_ENV: development # development
       POSTGRES_DB: management_yul_development
       POSTGRES_HOST: db


### PR DESCRIPTION
- This will continue to change with namespacing environment variables in AWS SSM