### PR TITLE
Pull METADATA_CLOUD_HOST from parameter store

### DIFF
--- a/lib/camerata/cluster.rb
+++ b/lib/camerata/cluster.rb
@@ -6,6 +6,7 @@ module Camerata
         VPN
         SAMPLE_BUCKET
         S3_SOURCE_BUCKET_NAME
+        METADATA_CLOUD_HOST
       ]
     end
   end


### PR DESCRIPTION
Add METADATA_CLOUD_HOST to the list of parameter store variables Camerata looks for