### PR TITLE
Make local-mode smoke test pass if only one item is seeded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: smoke specs
           command:  |
-            bundle exec rspec smoke_spec
+            bundle exec rspec smoke_spec --tag ~deployed:true
   run-tests:
     docker:
       - image: circleci/ruby:2.6-stretch-node-browsers-legacy
@@ -109,7 +109,7 @@ jobs:
       - run:
           name: smoke
           command: |
-            YUL_DC_SERVER=collections-deploy.curationexperts.com bundle exec cam smoke
+            YUL_DC_SERVER=collections-deploy.curationexperts.com bundle exec cam smoke --tag ~deployed:false
 orbs:
   docker: circleci/docker@1.0.1
 version: 2.1

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -46,7 +46,7 @@ ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
 RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
   describe "The blacklight site at #{blacklight_url}" do
     let(:uri) { "#{blacklight_url}/" }
-    it 'loads the home page for local environments', deployed:false do
+    it 'loads the home page for local environments', deployed: false do
       visit uri
       expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
@@ -62,7 +62,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       click_on 'search'
       expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
     end
-    it 'has a valid SSL certificate', deployed:true do
+    it 'has a valid SSL certificate', deployed: true do
       # this method is using the HTTP gem instead of capybara because
       # capybara.rb is configured to accept insecure certs to allow testing
       # deploys to ephemeral clusters
@@ -80,7 +80,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
     describe 'has a yale-only item' do
       let(:uri) { "#{blacklight_url}/catalog/2000002107188" }
       xit 'that does not show Universal Viewer' do
-        #test needs updating once we have real yale-only items
+        # test needs updating once we have real yale-only items
         visit uri
         expect(page).not_to have_selector(".universal-viewer-iframe")
       end
@@ -104,7 +104,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
           "sequence contains two canvases"
       end
     end
-    describe 'provides a manifest for item 16371253: ', deployed:true do
+    describe 'provides a manifest for item 16371253: ', deployed: true do
       let(:oid) { '16371253' }
       it 'has a sequence with nine canvases that links an image to a live URI' do
         response = HTTP.basic_auth(user: username,

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -46,20 +46,23 @@ ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
 RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
   describe "The blacklight site at #{blacklight_url}" do
     let(:uri) { "#{blacklight_url}/" }
-    it 'loads the home page' do
+    it 'loads the home page for local environments', deployed:false do
       visit uri
       expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
       expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
       expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/)
       click_on 'search'
-      expect(page).to have_selector(".document-position-4"), "an open search has at least 5 items"
+      expect(page).to have_selector(".document-position-0"), "an open search has at least 1 item"
     end
-    it 'has multiple pages of results in deployed environments', deployed: true do
+    it 'loads the home page for deployed environments', deployed: true do
       visit uri
+      expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
+      expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
+      expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/)
       click_on 'search'
       expect(page).to have_selector("[aria-label='Go to page 5']"), "an open search has at least 5 pages"
     end
-    it 'is local or has a valid SSL certificate' do
+    it 'has a valid SSL certificate', deployed:true do
       # this method is using the HTTP gem instead of capybara because
       # capybara.rb is configured to accept insecure certs to allow testing
       # deploys to ephemeral clusters
@@ -76,7 +79,8 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
     end
     describe 'has a yale-only item' do
       let(:uri) { "#{blacklight_url}/catalog/2000002107188" }
-      it 'that does not show Universal Viewer' do
+      xit 'that does not show Universal Viewer' do
+        #test needs updating once we have real yale-only items
         visit uri
         expect(page).not_to have_selector(".universal-viewer-iframe")
       end
@@ -100,7 +104,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
           "sequence contains two canvases"
       end
     end
-    describe 'provides a manifest for item 16371253: ' do
+    describe 'provides a manifest for item 16371253: ', deployed:true do
       let(:oid) { '16371253' }
       it 'has a sequence with nine canvases that links an image to a live URI' do
         response = HTTP.basic_auth(user: username,


### PR DESCRIPTION
* Disable private-item test which passes for the wrong reason

* Separate versions of open-search test when deployed tag is true vs.
when deployed tag is false

* Skip local-only tests in continuous-deploy scheduled CircleCI job

* Skip deployed-only tests in local-mode scheduled CircleCI job

Co-Authored-By: Max Kadel <max@curationexperts.com>