### PR TITLE
Make local-mode smoke test check for a facet the seed item supports

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
     it 'loads the home page for local environments', deployed: false do
       visit uri
       expect(page).to have_selector(".blacklight-catalog"), "not blocked by basic auth"
-      expect(page).to have_selector(".blacklight-language_ssim"), "a language facet is present"
+      expect(page).to have_selector(".blacklight-format"), "a format facet is present"
       expect(page).to have_selector(".branch-name", text: /v\d+\.\d+\.\d+/)
       click_on 'search'
       expect(page).to have_selector(".document-position-0"), "an open search has at least 1 item"


### PR DESCRIPTION
Context:  the smoke tests look for a language facet as a proxy for "are facets rendering on the front page".  But the single item that is being seeded when the management app first spins up doesn't have language metadata because it's a pen rather than a book or document.  Changing that test, in local mode, to check for one of the facets that does get populated with that ultra-minimal seed set.  ("format")