### PR TITLE
Update smoke specs for management now that CAS auth is in place

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -132,7 +132,9 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
     end
   end
   describe "The management index page at #{management_url}" do
-    it "has version numbers in the table" do
+    # This information is now protected behind CAS authentication.
+    # Removing this test for now. We will restore it when we have a CAS account.
+    xit "has version numbers in the table" do
       visit management_url
       expect(page).to have_selector("#management_version", text: /v\d+.\d+.\d+/)
       expect(page).to have_selector("#postgres_version", text: /v\d+.\d+.\d+/)
@@ -141,6 +143,10 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
       expect(page).to have_selector("#iiif_image_version", text: /v\d+.\d+.\d+/)
       expect(page).to have_selector("#iiif_manifest_version", text: /v\d+.\d+.\d+/)
       expect(page).to have_selector("#camerata_version", text: /v\d+.\d+.\d+/)
+    end
+    it "prompts the user to sign in" do
+      visit management_url
+      expect(page).to have_content('You must sign in')
     end
   end
 end

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "The cluster at #{blacklight_url}", type: :feature do
     end
     it "prompts the user to sign in" do
       visit management_url
-      expect(page).to have_content('You must sign in')
+      expect(page).to have_content('Sign in')
     end
   end
 end


### PR DESCRIPTION
The smoke specs for management need to temporarly check only that the front page responds and prompts for a user login. Later, when we have a CAS account we can use for this purpose, we can restore some more sophisticated smoke testing here.