### PR TITLE
Management can be run in prod mode locally

### DIFF
--- a/templates/management-compose.local.yml
+++ b/templates/management-compose.local.yml
@@ -7,7 +7,8 @@ services:
     <%- end -%>
     environment:
       ACCESS_MASTER_MOUNT: "s3" # The path to the mounted drive, or "S3"
-      PASSENGER_APP_ENV: development
+      PASSENGER_APP_ENV: ${PASSENGER_APP_ENV:-development}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       POSTGRES_MULTIPLE_DATABASES: management_yul_development
       SOLR_TEST_CORE: blacklight-test
     <%- if in_management? -%>
@@ -34,7 +35,8 @@ services:
     <%- end -%>
     environment:
       ACCESS_MASTER_MOUNT: "s3" # The path to the mounted drive, or "S3"
-      PASSENGER_APP_ENV: development
+      PASSENGER_APP_ENV: ${PASSENGER_APP_ENV:-development}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       POSTGRES_MULTIPLE_DATABASES: management_yul_development
       SOLR_TEST_CORE: blacklight-test
     <%- if in_management? -%>


### PR DESCRIPTION
- Separate this PR from cleanup PR

PASSENGER_APP_ENV=production cam up management

You'll then need to make the database with cam exec management bash -l -c 'RAILS_ENV=production rails db:create db:schema:load db:seed'