### PR TITLE
Disable scheduled CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,17 +118,3 @@ workflows:
     jobs:
       - run-tests:
           context: yul-dc
-  every-four-hours:
-    triggers:
-      - schedule:
-          cron: "40 1,5,9,13,17,21 * * *"
-          filters:
-            branches:
-              only:
-                - master
-                - smoke-scheduled-only
-    jobs:
-      - deploy-smoke:
-          context: yul-dc
-      - local-smoke:
-          context: yul-dc


### PR DESCRIPTION
Future work: run local-mode scheduled check pulling parameters from Yale 
AWS; run scheduled deploys against a continuous deploy cluster on yale 
infrastructure.