### PR TITLE
remove hardcoded urls

### DIFF
--- a/templates/blacklight-compose.ecs.yml
+++ b/templates/blacklight-compose.ecs.yml
@@ -6,7 +6,7 @@ services:
       HTTP_PASSWORD: ${HTTP_PASSWORD}
       HTTP_PASSWORD_PROTECT: ${BLACKLIGHT_PASSWORD_PROTECT}
       HTTP_USERNAME: ${HTTP_USERNAME}
-      IIIF_IMAGE_BASE_URL: 'https://collections-test.library.yale.edu/iiif'
+      IIIF_IMAGE_BASE_URL:
       IIIF_MANIFESTS_BASE_URL: /manifests/
       PASSENGER_APP_ENV: ${RAILS_ENV:-production}
       POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}

--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -4,8 +4,8 @@ services:
     environment:
       HTTP_USERNAME: ${HTTP_USERNAME}
       HTTP_PASSWORD: ${HTTP_PASSWORD}
-      IIIF_IMAGE_BASE_URL: 'https://collections-test.library.yale.edu/iiif'
-      IIIF_MANIFESTS_BASE_URL: 'https://collections-test.library.yale.edu/manifests'
+      IIIF_IMAGE_BASE_URL:
+      IIIF_MANIFESTS_BASE_URL:
       MC_USER: ${MC_USER}
       MC_PW: ${MC_PW}
       METADATA_CLOUD_HOST:
@@ -28,11 +28,11 @@ services:
     environment:
       HTTP_USERNAME: ${HTTP_USERNAME}
       HTTP_PASSWORD: ${HTTP_PASSWORD}
-      IIIF_IMAGE_BASE_URL: 'https://collections-test.library.yale.edu/iiif'
-      IIIF_MANIFESTS_BASE_URL: 'https://collections-test.library.yale.edu/manifests'
+      IIIF_IMAGE_BASE_URL:
+      IIIF_MANIFESTS_BASE_URL:
       MC_USER: ${MC_USER}
       MC_PW: ${MC_PW}
-      METADATA_CLOUD_HOST: 
+      METADATA_CLOUD_HOST:
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       HONEYBADGER_API_KEY_MANAGEMENT: ${HONEYBADGER_API_KEY_MANAGEMENT}
       POSTGRES_DB: management_yul_production


### PR DESCRIPTION
This PR removed hard-coded urls for IIIF_MANIFEST_BASE_URL and IIIF_IMAGE_BASE_URL, so we can get values from AWS SSM Parameter store. 

Connected to: https://github.com/yalelibrary/YUL-DC/issues/630