### PR TITLE
Updates to camerata parameter scripts

### DIFF
--- a/bin/build-cluster.sh
+++ b/bin/build-cluster.sh
@@ -133,9 +133,27 @@ task_definition:
   task_size:
     mem_limit: 4096
     cpu_limit: 1024
-  services:
-    management_worker:
-      mem_limit: 2048
+run_params:
+  network_configuration: awsvpc_configuration:
+      subnets:
+        - $SUBNET0
+        - $SUBNET1
+      security_groups:
+        - $SG_ID
+      assign_public_ip: $PUBLIC_IPS
+  service_discovery:
+    private_dns_namespace:
+      name: $CLUSTER_NAME
+      vpc: $VPC_ID
+ECS_PARAMS
+cat <<WORKER_PARAMS > ${CLUSTER_NAME}-worker-params.yml
+version: 1
+task_definition:
+  task_execution_role: ecsTaskExecutionRole
+  ecs_network_mode: awsvpc
+  task_size:
+    mem_limit: 4096
+    cpu_limit: 1024
 run_params:
   network_configuration:
     awsvpc_configuration:
@@ -149,6 +167,6 @@ run_params:
     private_dns_namespace:
       name: $CLUSTER_NAME
       vpc: $VPC_ID
-ECS_PARAMS
+WORKER_PARAMS
 
 fi

--- a/bin/deploy-worker.sh
+++ b/bin/deploy-worker.sh
@@ -30,9 +30,6 @@ then
     export COMPOSE_FILE=worker-compose.yml
   fi
 
-  #remove unnecessary and problematic task level memory constraints
-  yq delete ${CLUSTER_NAME}-ecs-params.yml  'task_definition.task_size' > $CLUSTER_NAME-worker-params.yml
-  # Launch the service and register containers with the loadbalancer
   ecs-cli compose  \
     --region $AWS_DEFAULT_REGION \
     --project-name ${CLUSTER_NAME}-worker \

--- a/bin/get-params.sh
+++ b/bin/get-params.sh
@@ -136,9 +136,6 @@ task_definition:
   task_size:
     mem_limit: $memory
     cpu_limit: $cpu
-  services:
-    management_worker:
-      mem_limit: 2048
 run_params:
   network_configuration:
     awsvpc_configuration:
@@ -153,6 +150,30 @@ run_params:
       name: $CLUSTER_NAME
       vpc: $VPC_ID
 ECS_PARAMS
+
+  cat <<WORKER_PARAMS > ${1}-worker-params.yml
+version: 1
+task_definition:
+  task_execution_role: ecsTaskExecutionRole
+  ecs_network_mode: awsvpc
+  task_size:
+    mem_limit: 4GB
+    cpu_limit: 1024
+run_params:
+  network_configuration:
+    awsvpc_configuration:
+      subnets:
+        - $SUBNET0
+        - $SUBNET1
+      security_groups:
+        - $SG_ID
+      assign_public_ip: $PUBLIC_IP
+  service_discovery:
+    private_dns_namespace:
+      name: $CLUSTER_NAME
+      vpc: $VPC_ID
+WORKER_PARAMS
+
 else
   echo "\nUSAGE: bin/cluster-ps.sh \$CLUSTER_NAME [memory] [cpu]\n" # Parameters not set correctly
 fi


### PR DESCRIPTION
* now creates $cluster-worker-params.yml in get-params and
create-cluster

t2.large instance parameters sized to allow for 2 tasks, or 1 task + a deploy