### PR TITLE
Add Dynatrace OneAgent to Camerata Base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby26:1.0.10
+FROM phusion/passenger-ruby26:1.1.0
 
 RUN echo 'Downloading Packages' && \
   curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
@@ -32,6 +32,9 @@ RUN yarn && \
   yarn config set silent
 
 RUN rm /etc/nginx/sites-enabled/default
+
+COPY --from=nhd42358.live.dynatrace.com/linux/oneagent-codemodules:all / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 ENV APP_HOME /home/app/webapp
 RUN mkdir $APP_HOME && chown -R app $APP_HOME

--- a/base/README.md
+++ b/base/README.md
@@ -20,7 +20,7 @@ It will ask you for a password. This is the PaaS token associated with Yale's Dy
 It can be accessed via 
 
 ```bash
-cam env_get DYNATRACE_TOKEN
+cam env_get /yul-dc-ingest/DYNATRACE_TOKEN
 ```
 
 Once you've logged in successfully you will need to rebuild your image. 

--- a/base/README.md
+++ b/base/README.md
@@ -5,3 +5,26 @@ simpler updates and more controlled changes to dependencies and for faster deplo
 
 It builds on the Phusion Passenger based Dockerfiles found here https://github.com/phusion/passenger-docker and 
 adds some common OS level dependencies that we need for our projects such as Node and Yarn.
+
+## Dynatrace
+
+We've integrated Dynatrace OneAgent for monitoring our Docker container environments. In order to correctly connect OneAgent with the Base image, you will need to sign into Dynatrace with the Dynatrace environment ID (nhd42358) and Activegate Address (https://nhd42358.live.dynatrace.com). 
+
+```bash
+cd base
+cam sh management 
+docker login -u nhd42358 https://nhd42358.live.dynatrace.com
+```
+
+It will ask you for a password. This is the PaaS token associated with Yale's Dynatrace account.
+It can be accessed via 
+
+```bash
+cam env_get VAR_NAME
+```
+
+Once you've logged in successfully you will need to rebuild your image. 
+
+```bash
+docker-compose build
+```

--- a/base/README.md
+++ b/base/README.md
@@ -20,7 +20,7 @@ It will ask you for a password. This is the PaaS token associated with Yale's Dy
 It can be accessed via 
 
 ```bash
-cam env_get VAR_NAME
+cam env_get DYNATRACE_TOKEN
 ```
 
 Once you've logged in successfully you will need to rebuild your image. 

--- a/lib/camerata/secrets.rb
+++ b/lib/camerata/secrets.rb
@@ -11,6 +11,7 @@ module Camerata
         MC_USER
         MC_PW
         RAILS_MASTER_KEY
+        DYNATRACE_TOKEN
       ]
     end
 


### PR DESCRIPTION
This PR adds Dynatrace OneAgent to the Camerata Base Image, bumps the Image version to 1.1.0 and adds instructions for OneAgent integration