### PR TITLE
Adds DEPLOYED_AT file to management containers in ECS

### DIFF
--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -20,6 +20,7 @@ services:
       SAMPLE_BUCKET:
       SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr
       POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
+    command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && /sbin/my_init" # server
     logging:
       driver: awslogs
       options:


### PR DESCRIPTION
This sets the command for the management container.
The default was "/sbin/my_init" prior to this change.
This PR follows the pattern used in the blacklight container command which first creates the DEPLOYED_AT file and then runs the prior default command.