### PR TITLE
Add ability to control number of worker processes for dj

### DIFF
--- a/templates/worker-compose.yml
+++ b/templates/worker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   management_worker:
     image: yalelibraryit/dc-management:${MANAGEMENT_VERSION}
-    command: /sbin/setuser app bash -l -c "bin/delayed_job_blocking -n 10"
+    command: /sbin/setuser app bash -l -c "bin/delayed_job_blocking -n ${WORKER_COUNT:- 1}"
     environment:
       <%= app_urls %>
       ACCESS_MASTER_MOUNT: "s3" # The path to the mounted drive, or "s3"


### PR DESCRIPTION
* set WORKER_COUNT shell variable to control # of workers spawned by
delayed job
* defaults to 1 process if unset