### PR TITLE
Deploy worker using existing worker-params.yml

### DIFF
--- a/bin/deploy-worker.sh
+++ b/bin/deploy-worker.sh
@@ -10,7 +10,7 @@ then
   echo "Using AWS_PROFILE=${AWS_PROFILE}";
   echo "      AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}";
 
-  if [[ ! -f ${1}-ecs-params.yml ]]
+  if [[ ! -f ${1}-worker-params.yml ]]
   then
     export PUBLIC_IP
     $(dirname "$0")/get-params.sh ${1}

--- a/bin/get-params.sh
+++ b/bin/get-params.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 . $(dirname "$0")/shared-checks.sh
 CLUSTER_NAME=$1
+echo "Using cluster name=${CLUSTER_NAME}"
+
 
 if [[ -z $2 ]]
 then
@@ -16,6 +18,8 @@ else
   cpu=$3
 fi
 PUBLIC_IP=${PUBLIC_IP:-DISABLED}
+echo "Using public ip =${PUBLIC_IP}"
+echo "Using VPC id=${VPC_ID}"
 
 if check_profile && check_region && check_cluster $1 && all_pass
 then
@@ -24,7 +28,7 @@ then
   echo "      mem_limit=${memory}"
   echo "      cpu_limit=${cpu}\n"
 
-  if [ "$VPC_ID" ] 
+  if [ "$VPC_ID" ]
   then
     if [ -z "$SUBNET0" ] | [ -z "$SUBNET1" ]
     then


### PR DESCRIPTION
Deploy-worker.sh was re-fetching params if ecs-params.yml didn't exist, but get-params doesn't create ecs-params anymore.