### PR TITLE
Revert "Add dynatrace support for solr image (#282)"

### DIFF
--- a/templates/solr-compose.ecs.yml
+++ b/templates/solr-compose.ecs.yml
@@ -9,11 +9,9 @@ services:
         awslogs-stream-prefix: solr
     volumes:
       - solr_efs:/var/solr/data/blacklight-core #this appears to not support variable expansion :/
-    command: bash -c 'cp -rn /opt/config/ /var/solr/data/$${SOLR_CORE}/conf && touch /var/solr/data/$${SOLR_CORE}/core.properties && exec /boot.sh'
+    command: bash -c 'cp -rn /opt/config/ /var/solr/data/$${SOLR_CORE}/conf && touch /var/solr/data/$${SOLR_CORE}/core.properties && exec solr -f'
     environment:
       SOLR_CORE: blacklight-core
-      CLUSTER_NAME: ${CLUSTER_NAME}
-      DYNATRACE_TOKEN: ${DYNATRACE_TOKEN}
 
 volumes:
   solr_efs:

--- a/templates/solr-compose.local.yml
+++ b/templates/solr-compose.local.yml
@@ -1,7 +1,10 @@
 version: '3'
 services:
   solr:
+    environment:
+      LD_PRELOAD: ""
     volumes:
+      # think this may need to be changed to /var/solr/data
       - solr:/opt/solr/server/solr/mycores
 volumes:
   solr:

--- a/templates/solr-compose.yml
+++ b/templates/solr-compose.yml
@@ -4,6 +4,6 @@ services:
     image: yalelibraryit/dc-solr:${SOLR_VERSION}
     ports:
       - '8983:8983'
-    command: bash -c 'precreate-core blacklight-core /opt/config; precreate-core blacklight-test /opt/config; exec /boot.sh'
+    command: bash -c 'precreate-core blacklight-core /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
     environment:
       SOLR_VERSION:


### PR DESCRIPTION
This reverts commit 1106842bf45dbbf679a8aa5c0a57a31e9e3cb55c.

- That commit broke local development using solr, in part because it did not generate solr cores. 