### PR TITLE
Moves activejob:schedule to production template

### DIFF
--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -30,7 +30,7 @@ services:
       SAMPLE_BUCKET:
       SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr
       POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
-    command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && /sbin/my_init" # server
+    command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && bundle exec rails activejob:schedule && /sbin/my_init" # server
     logging:
       driver: awslogs
       options:

--- a/templates/management-compose.yml
+++ b/templates/management-compose.yml
@@ -34,6 +34,5 @@ services:
       BLACKLIGHT_VERSION:
       MANAGEMENT_VERSION:
       CAMERATA_VERSION:
-    command: bash -c 'bundle exec rails activejob:schedule'
     ports:
       - "3001:3001"


### PR DESCRIPTION
# Summary
Moves activejob:schedule command from main to production template and removes sleep command.

# Related Ticket 
[#1620](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1620)