### PR TITLE
Add intensive_solr_index queue to list of queues processed by the intensive workers

### DIFF
--- a/bin/deploy-intensive-worker.sh
+++ b/bin/deploy-intensive-worker.sh
@@ -32,7 +32,7 @@ then
 
   # Define which queues the worker will pull jobs from
   # comman seperate like so pdf,ptiff,otherjob
-  export WORKER_QUEUES=pdf
+  export WORKER_QUEUES=pdf,intensive_solr_index
 
   ecs-cli compose  \
     --region $AWS_DEFAULT_REGION \


### PR DESCRIPTION
Process jobs in the intensive_solr_index queue in the intensive workers.

This will be used to process full text solr indexing at a slower rate to reduce load on Solr.
Management will put solr index jobs that have full text into this queue rather than the default solr index queue.