### PR TITLE
Adds automation command for active job scheduler

### DIFF
--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -30,7 +30,7 @@ services:
       SAMPLE_BUCKET:
       SOLR_BASE_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr
       POSTGRES_HOST: ${CLUSTER_NAME}-psql.${CLUSTER_NAME}
-    command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && /sbin/my_init" # server
+    command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && bundle exec rails activejob:schedule && /sbin/my_init" # server
     logging:
       driver: awslogs
       options:


### PR DESCRIPTION
# Summary
Adds command to start active job scheduler when production container is started.  

# Related Ticket
[#1883](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/1883)