### PR TITLE
Update docker base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby27:2.1.0
+FROM phusion/passenger-ruby27:2.3.0
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   curl -sL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.3.0
+    image: yalelibraryit/dc-base:v1.3.2


### PR DESCRIPTION
## Summary
Update docker base from 2.1.0 to 2.3.0

## Related Ticket
[#2115](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2115)