### PR TITLE
Upgrade dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.4'
+
 # Specify your gem's dependencies in camerata.gemspec
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,5 +165,8 @@ DEPENDENCIES
   vcr
   webmock
 
+RUBY VERSION
+   ruby 2.7.4p191
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
# Summary
Upgrading nokogiri caused a dependency issue because the camerata repo was using ruby v2.5.1 and that wasn't compatible with the new nokogiri package.  This MR pins the ruby version to v2.7.4 to fix the dependency conflict and upgrades several dependencies along with it.

# Related Ticket
[#2115](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2115)