### PR TITLE
M1 Selenium Tests - use an external chrome image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docker-compose-merged.yml
 .rspec_status
 vendor
 tags
+*~undo-tree~

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,8 @@
 FROM phusion/passenger-ruby27:2.3.0
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  curl -sL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   curl -sL   https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-  echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
   sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
   curl -sL https://deb.nodesource.com/setup_16.x | bash - > /dev/null && \
   DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends \
@@ -13,8 +11,7 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     nodejs \
     rsync \
     yarn \
-    postgresql-client-12 \
-    google-chrome-stable && \
+    postgresql-client-12 && \
     apt-get autoremove -y && \
     apt-get clean
 

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.3.2
+    image: yalelibraryit/dc-base:v1.4.0

--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -396,6 +396,7 @@ module Camerata
           "blacklight-compose.local.yml",
           "iiif-images-compose.yml",
           "iiif-images-compose.local.yml",
+          "chrome-compose.local.yml",
           "db-compose.yml",
           "db-compose.local.yml",
           "solr-compose.yml",

--- a/templates/chrome-compose.local.yml
+++ b/templates/chrome-compose.local.yml
@@ -7,8 +7,6 @@ services:
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 3G
-    networks:
-      internal:
     environment:
       JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps=
     ports:

--- a/templates/chrome-compose.local.yml
+++ b/templates/chrome-compose.local.yml
@@ -1,0 +1,15 @@
+services:
+  chrome:
+    # password is 'secret'
+    image: seleniarm/standalone-chromium:latest
+    logging:
+      driver: none
+    volumes:
+      - /dev/shm:/dev/shm
+    shm_size: 3G
+    networks:
+      internal:
+    environment:
+      JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps=
+    ports:
+      - 7900:7900

--- a/templates/chrome-compose.local.yml
+++ b/templates/chrome-compose.local.yml
@@ -2,8 +2,6 @@ services:
   chrome:
     # password is 'secret'
     image: seleniarm/standalone-chromium:latest
-    logging:
-      driver: none
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 3G

--- a/templates/management-compose.local.yml
+++ b/templates/management-compose.local.yml
@@ -36,4 +36,7 @@ services:
       <%- unless without.match(/solr/) -%>
       - solr
       <%- end -%>
+      <%- unless without.match(/chrome/) -%>
+      - chrome
+      <%- end -%>
       - management_worker


### PR DESCRIPTION
# Summary
This has the advantage of removing chrome from our main image, slimming it down.

# Related Ticket
Ref https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2073
