### PR TITLE
Add SOLR_HEAP environment variable to local Solr template

### DIFF
--- a/templates/solr-compose.local.yml
+++ b/templates/solr-compose.local.yml
@@ -4,5 +4,7 @@ services:
     volumes:
       # think this may need to be changed to /var/solr/data
       - solr:/opt/solr/server/solr/mycores
+    environment:
+      SOLR_HEAP: ${SOLR_HEAP}
 volumes:
   solr:


### PR DESCRIPTION
Add SOLR_HEAP environment variable to local Solr template.   Allows users to specify a value ('2g') so that the Solr JVM doesn't default to the production size (currently 12g).