### PR TITLE
Upgrade phusion passenger ruby27 version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,7 @@
 FROM phusion/passenger-ruby27:2.3.1
 
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+RUN apt-get update && \
+  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   curl -sL   https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby27:2.3.0
+FROM phusion/passenger-ruby27:2.3.1
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   curl -sL   https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.4.0
+    image: yalelibraryit/dc-base:v1.4.1


### PR DESCRIPTION
# Summary
Upgrades phusion/passenger-ruby27 to version 2.3.1

Related Ticket
[#2295](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2295)