### PR TITLE
Upgrades to ruby 3.1.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       concurrent-ruby (~> 1.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.14.1)
+    minitest (5.17.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nokogiri (1.13.10)
@@ -166,4 +166,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby27:2.3.1
+FROM phusion/passenger-ruby27:2.4.1
 
 RUN apt-get update && \
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.4.1
+    image: yalelibraryit/dc-base:v1.4.2

--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -365,7 +365,7 @@ module Camerata
       result = {}
       inputs.each do |input|
         file_path = File.join(self.class.source_root, input)
-        content = ERB.new(::File.binread(file_path), nil, "-", "@output_buffer").result(binding)
+        content = ERB.new(::File.binread(file_path), trim_mode: "-", eoutvar: "@output_buffer").result(binding)
         input_yaml = YAML.safe_load(content)
         result.deep_merge!(input_yaml)
       end


### PR DESCRIPTION
# Summary
Upgrades phusion passenger image to version that includes ruby 3.1.3 and changes ruby version to 3.1.3.  Also addresses [deprecation warnings](https://bugs.webkit.org/show_bug.cgi?id=236684) from `/lib/camerata.rb:368` and updates base image version.

# Related Ticket
[#2348](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/gh/yalelibrary/yul-dc/2348)