### PR TITLE
Removes rails master key from local development variables

### DIFF
--- a/templates/management-compose.local.yml
+++ b/templates/management-compose.local.yml
@@ -15,7 +15,6 @@ services:
       PDF_BASE_URL: "http://localhost/pdfs/"
       PASSENGER_APP_ENV: ${PASSENGER_APP_ENV:-development}
       POSTGRES_MULTIPLE_DATABASES: management_yul_development
-      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       SAMPLE_BUCKET: yul-dc-development-samples # manifests
       S3_SOURCE_BUCKET_NAME: yul-dc-dev-image-samples # image and ptiffs
       S3_DOWNLOAD_BUCKET_NAME: yul-dc-download-test # downloadable originals


### PR DESCRIPTION
# Summary
Was unable to spin up management due to an issue with the updated key.  Removing the variable allows for management to be spun up again for local development.