### PR TITLE
Remove space from URL in template

### DIFF
--- a/templates/blacklight-compose.local.yml
+++ b/templates/blacklight-compose.local.yml
@@ -14,7 +14,7 @@ services:
       IIIF_IMAGE_UPSTREAM_PORT: 3000
       IIIF_IMAGE_UPSTREAM_PROTO: http
       PDF_BASE_URL: "http://localhost/pdfs/"
-      MANAGEMENT_HOST: " http://localhost:3001/management"
+      MANAGEMENT_HOST: "http://localhost:3001/management"
       PASSENGER_APP_ENV: development
       POSTGRES_DB: blacklight_yul_development
       SAMPLE_BUCKET: yul-dc-development-samples # manifests


### PR DESCRIPTION
Space breaks API call from BL to Management in local development.