### PR TITLE
Change image storage location

### DIFF
--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -8,7 +8,7 @@ services:
       DYNATRACE_TOKEN: ${DYNATRACE_TOKEN}
       AWS_DEFAULT_REGION: us-east-1
       AWS_SECRET_ACCESS_KEY: ${DEPLOY_ACCESS_KEY}
-      ACCESS_MASTER_MOUNT: "/data" # The path to the mounted drive, or "s3"
+      ACCESS_MASTER_MOUNT: "s3" # The path to the mounted drive, or "s3"
       GOOBI_MOUNT:
       GOOBI_SCAN_DIRECTORIES:
       INGEST_ERROR_EMAIL:

--- a/templates/worker-compose.ecs.yml
+++ b/templates/worker-compose.ecs.yml
@@ -17,7 +17,7 @@ services:
       MC_USER: ${MC_USER}
       MC_PW: ${MC_PW}
       METADATA_CLOUD_HOST:
-      ACCESS_MASTER_MOUNT: "/data" # The path to the mounted drive, or "s3"
+      ACCESS_MASTER_MOUNT: "s3" # The path to the mounted drive, or "s3"
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       HONEYBADGER_API_KEY_MANAGEMENT: ${HONEYBADGER_API_KEY_MANAGEMENT}
       POSTGRES_DB: management_yul_production


### PR DESCRIPTION
# Summary
During preservica resync jobs the process failed due to being unable to find the original file.  This PR updates the location of image storage to match the rest of the environments.

# Related Ticket
[#2779](https://github.com/yalelibrary/YUL-DC/issues/2779)