### PR TITLE
Update docker compose command

### DIFF
--- a/lib/camerata.rb
+++ b/lib/camerata.rb
@@ -452,7 +452,7 @@ IIIF_IMAGE_BASE_URL: ${IIIF_IMAGE_BASE_URL:-http://localhost:8182/iiif}
     end
 
     def docker_compose
-      "docker-compose -p yul-dc --project-directory . -f #{compose_path}"
+      "docker compose -p yul-dc --project-directory . -f #{compose_path}"
     end
 
     def prep_answer(answer)


### PR DESCRIPTION
# Summary
Newer versions of Docker use `docker compose` instead of `docker-compose`.  This PR updates camerata to use the most current syntax for constructing containers.

