### PR TITLE
Pin concurrent ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     camerata (4.1.2)
       activesupport (~> 6.1.7.5)
       capybara (~> 3.33.0)
+      concurrent-ruby (< 1.3.5)
       http (~> 4.4.1)
       rspec (~> 3.0)
       selenium-webdriver (~> 3.142)

--- a/camerata.gemspec
+++ b/camerata.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+# https://github.com/rails/rails/pull/54264
+  spec.add_dependency 'concurrent-ruby', '< 1.3.5'
   spec.add_runtime_dependency "capybara", "~> 3.33.0"
   spec.add_runtime_dependency "http", "~> 4.4.1"
   spec.add_runtime_dependency "rspec", "~> 3.0"

--- a/camerata.gemspec
+++ b/camerata.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-# https://github.com/rails/rails/pull/54264
+  # https://github.com/rails/rails/pull/54264
   spec.add_dependency 'concurrent-ruby', '< 1.3.5'
   spec.add_runtime_dependency "capybara", "~> 3.33.0"
   spec.add_runtime_dependency "http", "~> 4.4.1"


### PR DESCRIPTION
# Summary
Recent release of `concurrent-ruby` has a bug - see issue: https://github.com/rails/rails/pull/54264.  This PR pins the release to the release prior to the bug to prevent errors with logger.

