### PR TITLE
Solr Continuity

### DIFF
--- a/lib/camerata/secrets.rb
+++ b/lib/camerata/secrets.rb
@@ -23,6 +23,7 @@ module Camerata
         SSO_SECRET
         SSO_JWKS
         SSO_ISS
+        SOLR_URL
         SOLR_BASE_URL
         SOLR_URL_WITH_CORE
       ]

--- a/templates/blacklight-compose.ecs.yml
+++ b/templates/blacklight-compose.ecs.yml
@@ -24,7 +24,7 @@ services:
       RAILS_ENV: ${RAILS_ENV:-production}
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       SAMPLE_BUCKET:
-      SOLR_URL: http://${CLUSTER_NAME}-solr.${CLUSTER_NAME}:8983/solr/blacklight-core
+      SOLR_URL: ${SOLR_URL_WITH_CORE}
       SOLR_BASE_URL: ${SOLR_BASE_URL}
       SOLR_URL_WITH_CORE: ${SOLR_URL_WITH_CORE}
     command: bash -c "echo $$(date -u +%FT%TZ) > DEPLOYED_AT && sleep 30 && /sbin/my_init" # server


### PR DESCRIPTION
# Summary
Updates Solr variables to allow for older releases on production to operate while also using expected values for new Solr instance.  Also, removes hardcoded values from blacklight template that were causing repeated values in params on AWS.

# Related Ticket
[#2988](https://github.com/yalelibrary/YUL-DC/issues/2988)