### PR TITLE
blacklight containers 2vcpu -> 4vcpu

### DIFF
--- a/bin/get-params.sh
+++ b/bin/get-params.sh
@@ -163,7 +163,7 @@ task_definition:
   ecs_network_mode: awsvpc
   task_size:
     mem_limit: $memory
-    cpu_limit: $cpu
+    cpu_limit: 4096
 run_params:
   network_configuration:
     awsvpc_configuration:


### PR DESCRIPTION
If the CPU value isnt passed into the get-params.sh as an argument, the default is 2: https://github.com/yalelibrary/yul-dc-camerata/blob/9eca9d8a2cb64730b2ab67b7b7557485922d539e/bin/get-params.sh#L17

Looks like the worker and image containers override this value by not relying on it being passed in and rather explicitly defined here also