### PR TITLE
Dynatrace cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camerata (4.1.2)
+    camerata (4.1.3)
       activesupport (~> 6.1.7.5)
       capybara (~> 3.33.0)
       concurrent-ruby (< 1.3.5)

--- a/README.md
+++ b/README.md
@@ -49,18 +49,13 @@ ENV['AWS_PROFILE'] = 'your_profile'
 ENV['CLUSTER_NAME'] = 'yul-test'
 ```
 
-## Dynatrace
-
-We've integrated Dynatrace OneAgent for monitoring our Docker container environments.
-  - Instructions on configuring OneAgent can be found [here](https://github.com/yalelibrary/yul-dc-camerata/tree/main/base)
-
 ## General Use
 
 Once camerata is installed on your system, interactions happen through the camerata command-line tool or through its alias `cam`. The camerata tool can be used to bring the development stack up and down locally, interact with the docker containers, deploy, run the smoke tests and otherwise do development tasks common to the various applications in the yul-dc application stack.
 
 All builtin commands can be listed with `cam help` and individual usage information is available with `cam help COMMAND`. Please note that deployment commands (found in the `./bin` directory) are passed through and are therefore not listed by the help command. See the usage for those below.
 
-To start the application stack, run `cam up` in the directory you are working in. Example: If you are working in the Blacklight repo, run `cam up` inside the yul-dc-blacklight directory. This is the equivalent of running `docker-compose up blacklight`. This starts all of the applications as they are all dependencies of yul-blacklight. Camerata is smart. If you start `cam up` from a blacklight code check out it will mount that code for local development (changes to the outside code will affect the inside container). If you start the `cam up` from the management application you will get the management code mounted for local development and the blacklight code will run as it is in the downloaded image. You can also start the two applications both mounted for development by starting the blacklight application with `cam up blacklight --without management`, and the management application as normal (`cam up management`); each from their respective code checkouts.
+To start the application stack, run `cam up` in the directory you are working in. Example: If you are working in the Blacklight repo, run `cam up` inside the yul-dc-blacklight directory. This is the equivalent of running `docker compose up blacklight`. This starts all of the applications as they are all dependencies of yul-blacklight. Camerata is smart. If you start `cam up` from a blacklight code check out it will mount that code for local development (changes to the outside code will affect the inside container). If you start the `cam up` from the management application you will get the management code mounted for local development and the blacklight code will run as it is in the downloaded image. You can also start the two applications both mounted for development by starting the blacklight application with `cam up blacklight --without management`, and the management application as normal (`cam up management`); each from their respective code checkouts.
 
 - Access the blacklight app at `http://localhost:3000`
 
@@ -84,8 +79,8 @@ The base docker image, used for our two Ruby on Rails applications (Management a
 
 ```bash
 cd base
-docker-compose build
-docker-compose push
+docker compose build
+docker compose push
 ```
 
 Then you'll need to prep cam for use locally.

--- a/base/README.md
+++ b/base/README.md
@@ -32,7 +32,7 @@ In the Camerata repo:
 **Push Image**
 
 Once you have a Dockerfile that is the correct recipe for your image:
-- Run `docker-compose push`
+- Run `docker compose push`
 - Commit your changes and make a **PR**
 - Run `rake install`
     - This will set you up to test the build with the downstream services

--- a/base/README.md
+++ b/base/README.md
@@ -51,5 +51,5 @@ For each **downstream image** that will require the update from base:
 - Commit your changes and make a **PR**
 
 ```bash	
-docker-compose build	
+docker compose build	
 ```

--- a/base/README.md
+++ b/base/README.md
@@ -24,10 +24,10 @@ In the Camerata repo:
     - This will ensure that each build will be tagged with the **new** version number
 - Open `base/Dockerfile` in your editor
 - Make your changes
-- Run `docker-compose build` to build the image
+- Run `docker compose build` to build the image
 - Confirm that the image builds
-- Run `docker-compose up` to start up the service
-- In another window run `docker-compose exec base bash` to connect to the running container and examine its contents
+- Run `docker compose up` to start up the service
+- In another window run `docker compose exec base bash` to connect to the running container and examine its contents
 
 **Push Image**
 
@@ -49,10 +49,6 @@ For each **downstream image** that will require the update from base:
     - Run `cam up <service-name>`
     - Check to see that the service comes up and behaves as expected
 - Commit your changes and make a **PR**
-
-## Dynatrace	
-
-We've integrated Dynatrace OneAgent for monitoring our Docker container environments. The Dynatrace dashboard can be reached here https://nhd42358.live.dynatrace.com. 
 
 ```bash	
 docker-compose build	

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3'
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.4.5
+    image: yalelibraryit/dc-base:v1.4.6

--- a/base/ops/boot.sh
+++ b/base/ops/boot.sh
@@ -1,8 +1,2 @@
 #!/bin/bash
 set -e
-#This script is run by /sbin/my_init at boot time
-if [ ! -z "$DYNATRACE_TOKEN" ];then
-
-  curl -Ls -H "Authorization: Api-Token ${DYNATRACE_TOKEN}" 'https://nhd42358.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default' > installer.sh && \
-  /bin/sh installer.sh  --set-app-log-content-access=true --set-infra-only=true --set-host-group=DC --set-host-name=${CLUSTER_NAME}-${TYPE} NON_ROOT_MODE=0 &
-fi

--- a/bin/create-continst.sh
+++ b/bin/create-continst.sh
@@ -102,13 +102,6 @@ CLUSTER_NAME=$1
   USERDATA=$(echo "#!/bin/bash
   echo ECS_CLUSTER=$CLUSTER_NAME >> /etc/ecs/ecs.config && yum update -y
 
-  # Install Dynatrace OneAgent client
-  yum install -y wget
-  wget -O Dynatrace-OneAgent-Linux-1.201.129.sh \
-    \"https://nhd42358.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default\" \
-    --header=\"Authorization: Api-Token ${DYNATRACE_TOKEN}\"
-  /bin/sh Dynatrace-OneAgent-Linux-1.201.129.sh --set-app-log-content-access=true --set-infra-only=true --set-host-group=DC --set-host-name=${CLUSTER_NAME}-worker
-
   # NFS mount Goobi Hot Folders
   mkdir -p /brbl-dsu/jss_export
   mkdir -p /brbl-dsu/dcs

--- a/bin/update-continst.sh
+++ b/bin/update-continst.sh
@@ -102,13 +102,6 @@ CLUSTER_NAME=$1
   USERDATA=$(echo "#!/bin/bash
   echo ECS_CLUSTER=$CLUSTER_NAME >> /etc/ecs/ecs.config && yum update -y
 
-  # Install Dynatrace OneAgent client
-  yum install -y wget
-  wget -O Dynatrace-OneAgent-Linux-1.201.129.sh \
-    \"https://nhd42358.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default\" \
-    --header=\"Authorization: Api-Token ${DYNATRACE_TOKEN}\"
-  /bin/sh Dynatrace-OneAgent-Linux-1.201.129.sh --set-app-log-content-access=true --set-infra-only=true --set-host-group=DC --set-host-name=${CLUSTER_NAME}-worker
-
   # NFS mount Goobi Hot Folders
   mkdir -p /brbl-dsu/jss_export
   mkdir -p /brbl-dsu/dcs

--- a/lib/camerata/version.rb
+++ b/lib/camerata/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Camerata
-  VERSION = '4.1.2'
+  VERSION = '4.1.3'
 end

--- a/templates/blacklight-compose.ecs.yml
+++ b/templates/blacklight-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   blacklight:
     environment:

--- a/templates/blacklight-compose.local.yml
+++ b/templates/blacklight-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   blacklight:
     <%- if in_blacklight? -%>

--- a/templates/blacklight-compose.yml
+++ b/templates/blacklight-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   blacklight:
     image: yalelibraryit/dc-blacklight:${BLACKLIGHT_VERSION}

--- a/templates/db-compose.ecs.yml
+++ b/templates/db-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     command: /bin/bash -c '/boot.sh'

--- a/templates/db-compose.local.yml
+++ b/templates/db-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     environment:

--- a/templates/db-compose.yml
+++ b/templates/db-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: yalelibraryit/dc-postgres:${POSTGRES_VERSION}

--- a/templates/iiif-images-compose.ecs.yml
+++ b/templates/iiif-images-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   iiif_image:
     logging:

--- a/templates/iiif-images-compose.local.yml
+++ b/templates/iiif-images-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   iiif_image:
     build: .

--- a/templates/iiif-images-compose.yml
+++ b/templates/iiif-images-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   iiif_image:
     image: yalelibraryit/dc-iiif-cantaloupe:${IIIF_IMAGE_VERSION}

--- a/templates/intensive-compose.ecs.yml
+++ b/templates/intensive-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     environment:

--- a/templates/intensive-compose.local.yml
+++ b/templates/intensive-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     <%- if in_management? -%>

--- a/templates/intensive-compose.yml
+++ b/templates/intensive-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     image: yalelibraryit/dc-management:${MANAGEMENT_VERSION}

--- a/templates/management-compose.ecs.yml
+++ b/templates/management-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     environment:

--- a/templates/management-compose.local.yml
+++ b/templates/management-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     <%- if in_management? -%>

--- a/templates/management-compose.yml
+++ b/templates/management-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management:
     image: yalelibraryit/dc-management:${MANAGEMENT_VERSION}

--- a/templates/solr-compose.ecs.yml
+++ b/templates/solr-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   solr:
     logging:

--- a/templates/solr-compose.local.yml
+++ b/templates/solr-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   solr:
     volumes:

--- a/templates/solr-compose.yml
+++ b/templates/solr-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   solr:
     image: yalelibraryit/dc-solr:${SOLR_VERSION}

--- a/templates/worker-compose.ecs.yml
+++ b/templates/worker-compose.ecs.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   management_worker:
     environment:

--- a/templates/worker-compose.local.yml
+++ b/templates/worker-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management_worker:
     <%- if in_management? -%>

--- a/templates/worker-compose.yml
+++ b/templates/worker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   management_worker:
     image: yalelibraryit/dc-management:${MANAGEMENT_VERSION}


### PR DESCRIPTION
# Summary
Removes references to Dynatrace and removes usage.  Also, removes deprecated docker syntax for `version` to eliminate deprecation warnings.

# Related Ticket
[#3100](https://github.com/yalelibrary/YUL-DC/issues/3100)