### PR TITLE
Updates passenger image for newer version of ubuntu

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby32:2.5.1
+FROM phusion/passenger-ruby32:3.1.3
 
 RUN apt-get update && \
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -1,4 +1,4 @@
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.4.6
+    image: yalelibraryit/dc-base:v1.4.7


### PR DESCRIPTION
# Summary
Updates passenger in base image to incorporate Ubuntu 24.04

# Related Ticket
[#3127](https://github.com/yalelibrary/YUL-DC/issues/3127)