### PR TITLE
Update Smoke Specs for Download Original 

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -256,9 +256,9 @@ RSpec.describe "The cluster at #{ENV['CLUSTER_NAME']}", type: :feature do
           action_uri = "#{blacklight_url}/download/tiff/#{owp_child_oid}/staged"
           retrieval_uri = "#{blacklight_url}/download/tiff/#{owp_child_oid}"
           response = HTTP.get(action_uri, ssl_context: ssl_context)
-          expect(response.code).to eq(401), 'has unauthorized response'
+          expect(response.code).to eq(404), 'not-found'
           response = HTTP.get(retrieval_uri, ssl_context: ssl_context)
-          expect(response.code).to eq(401), 'does not serve a tiff'
+          expect(response.code).to eq(404), 'not-found'
         end
       end
       describe 'pdfs' do


### PR DESCRIPTION
## Summary  
Refactor Download Original changes the response from 401 to 404 to prevent leaking oid numbers. This PR updates the smoke spec to expect a 404 instead of a 401.