### PR TITLE
Upgrade base to phusion passenger-ruby32:3.1.6

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby32:3.1.3
+FROM phusion/passenger-ruby32:3.1.6
 
 RUN apt-get update && \
   curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -1,4 +1,4 @@
 services:
   base:
     build: .
-    image: yalelibraryit/dc-base:v1.4.7
+    image: yalelibraryit/dc-base:v1.4.8


### PR DESCRIPTION
# Summary
Upgrades the base image used to phusion/passenger-ruby32:3.1.6.

# Related Ticket
[#3392](https://github.com/yalelibrary/YUL-DC/issues/3392)